### PR TITLE
remove role from bucket when deleting project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
         "google/cloud-resource-manager": "^0.3.5",
-        "keboola/storage-driver-common": "^2.3",
+        "keboola/storage-driver-common": "dev-roman-clear-permission-from-bucket-when-project-is-dropped as 2.3",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.12.1",
         "google/cloud-bigquery": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
         "google/cloud-resource-manager": "^0.3.5",
-        "keboola/storage-driver-common": "dev-roman-clear-permission-from-bucket-when-project-is-dropped as 2.3",
+        "keboola/storage-driver-common": "^2.4",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.12.1",
         "google/cloud-bigquery": "^1.23",

--- a/src/Handler/Project/Drop/DropProjectHandler.php
+++ b/src/Handler/Project/Drop/DropProjectHandler.php
@@ -36,14 +36,13 @@ final class DropProjectHandler implements DriverCommandHandlerInterface
         $iamService = $this->clientManager->getIamClient($credentials);
         $serviceAccountsService = $iamService->projects_serviceAccounts;
         $commandMeta = $command->getMeta();
-        if ($commandMeta !== null) {
-            // override root user and use other database as root
-            $commandMeta = $commandMeta->unpack();
-            assert($commandMeta instanceof DropProjectCommand\DropProjectBigqueryMeta);
-            $fileStorageBucketName = $commandMeta->getGcsFileBucketName();
-        } else {
-            throw new Exception('CreateProjectBigqueryMeta is required.');
+        if ($commandMeta === null) {
+            throw new Exception('DropProjectBigqueryMeta is required.');
         }
+
+        $commandMeta = $commandMeta->unpack();
+        assert($commandMeta instanceof DropProjectCommand\DropProjectBigqueryMeta);
+        $fileStorageBucketName = $commandMeta->getGcsFileBucketName();
 
         /** @var array<string, string>|false $publicPartKeyFile */
         $publicPartKeyFile = json_decode($command->getProjectUserName(), true, 512, JSON_THROW_ON_ERROR);

--- a/src/Handler/Project/Drop/DropProjectHandler.php
+++ b/src/Handler/Project/Drop/DropProjectHandler.php
@@ -7,8 +7,8 @@ namespace Keboola\StorageDriver\BigQuery\Handler\Project\Drop;
 use Exception;
 use Google\Cloud\Billing\V1\ProjectBillingInfo;
 use Google\Protobuf\Internal\Message;
+use Google\Service\Iam\ServiceAccount;
 use Keboola\StorageDriver\BigQuery\GCPClientManager;
-use Keboola\StorageDriver\BigQuery\NameGenerator;
 use Keboola\StorageDriver\Command\Project\DropProjectCommand;
 use Keboola\StorageDriver\Contract\Driver\Command\DriverCommandHandlerInterface;
 use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
@@ -35,10 +35,34 @@ final class DropProjectHandler implements DriverCommandHandlerInterface
 
         $iamService = $this->clientManager->getIamClient($credentials);
         $serviceAccountsService = $iamService->projects_serviceAccounts;
+        $commandMeta = $command->getMeta();
+        if ($commandMeta !== null) {
+            // override root user and use other database as root
+            $commandMeta = $commandMeta->unpack();
+            assert($commandMeta instanceof DropProjectCommand\DropProjectBigqueryMeta);
+            $fileStorageBucketName = $commandMeta->getGcsFileBucketName();
+        } else {
+            throw new Exception('CreateProjectBigqueryMeta is required.');
+        }
 
         /** @var array<string, string>|false $publicPartKeyFile */
         $publicPartKeyFile = json_decode($command->getProjectUserName(), true, 512, JSON_THROW_ON_ERROR);
         assert($publicPartKeyFile !== false);
+
+        $storageManager = $this->clientManager->getStorageClient($credentials);
+        $fileStorageBucket = $storageManager->bucket($fileStorageBucketName);
+
+        $policy = $fileStorageBucket->iam()->policy();
+
+        foreach ($policy['bindings'] as $bindingKey => $binding) {
+            if ($binding['role'] === 'roles/storage.objectAdmin') {
+                $key = array_search('serviceAccount:'.$publicPartKeyFile['client_email'], $binding['members']);
+                unset($policy['bindings'][$bindingKey]['members'][$key]);
+            }
+        }
+
+        $fileStorageBucket->iam()->setPolicy($policy);
+
         $projectId = (string) $publicPartKeyFile['project_id'];
         $serviceAccountsInProject = $serviceAccountsService->listProjectsServiceAccounts(
             sprintf('projects/%s', $projectId)
@@ -46,7 +70,6 @@ final class DropProjectHandler implements DriverCommandHandlerInterface
         foreach ($serviceAccountsInProject as $item) {
             $serviceAccountsService->delete(sprintf('projects/%s/serviceAccounts/%s', $projectId, $item->getEmail()));
         }
-
         $projectsClient = $this->clientManager->getProjectClient($credentials);
 
         $formattedName = $projectsClient->projectName($projectId);


### PR DESCRIPTION
Common driver PR: https://github.com/keboola/php-storage-driver-common/pull/23 
Pridal som mazanie roli z bucketu ktory sa pouziva ako file storage pri mazani projektu pretoze, u GCP tam tie role ostanu priradene aj po zmazani servisneho uctu a mazu sa automaticky az po 2 mesiachoch a obcas hitneme limit a failnu testy