### PR TITLE
edit RO name generator to generate same name as snflk

### DIFF
--- a/src/Handler/Project/Create/CreateProjectHandler.php
+++ b/src/Handler/Project/Create/CreateProjectHandler.php
@@ -151,7 +151,7 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
         $location = GCPClientManager::DEFAULT_LOCATION;
         $formattedParent = $analyticHubClient->locationName($projectCreateResult->getProjectId(), $location);
 
-        $dataExchangeId = $nameGenerator->createDataExchangeId($projectCreateResult->getProjectId());
+        $dataExchangeId = $nameGenerator->createDataExchangeId($command->getProjectId());
         $dataExchange = new DataExchange();
         $dataExchange->setDisplayName($dataExchangeId);
         $analyticHubClient->createDataExchange($formattedParent, $dataExchangeId, $dataExchange);

--- a/src/NameGenerator.php
+++ b/src/NameGenerator.php
@@ -50,8 +50,8 @@ class NameGenerator
         return $this->stackPrefix . '-workspace-' . $workspaceId;
     }
 
-    public function createDataExchangeId(string $projectStringId): string
+    public function createDataExchangeId(string $projectId): string
     {
-        return str_replace('-', '_', $projectStringId) . '_SHARE_exchanger';
+        return str_replace('-', '_', strtoupper($this->stackPrefix) . '_' . $projectId) . '_RO';
     }
 }

--- a/tests/unit/NameGeneratorTest.php
+++ b/tests/unit/NameGeneratorTest.php
@@ -60,9 +60,8 @@ class NameGeneratorTest extends TestCase
     {
         $nameGenerator = new NameGenerator('KBC_prefix_');
         $this->assertSame(
-            'local_project_12_02_09_04_31_SHARE_exchanger',
-            $nameGenerator->createDataExchangeId('local-project-12-02-09-04-31')
+            'KBC_PREFIX_123_RO',
+            $nameGenerator->createDataExchangeId('123')
         );
-        $this->assertSame('project_SHARE_exchanger', $nameGenerator->createDataExchangeId('project'));
     }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/CT-1149 
v connection mame chybu ze neukladama RO rolu pre kazdy backend, takze ak mam multi projekt tak podla toho ktory backend sa zalozil prvi tak podla toho je znenie tej role. Upravujem preto namegenerator. Pak poslem PR do connection a zalozim nove projekty.