### PR TITLE
BIG-168 Add retries for GoogleClient

### DIFF
--- a/src/GCPClientManager.php
+++ b/src/GCPClientManager.php
@@ -14,7 +14,6 @@ use Google\Cloud\Storage\StorageClient;
 use Google\Service\Iam;
 use Google_Client;
 use Google_Service_CloudResourceManager;
-use Google_Service_Iam;
 use GuzzleHttp\Client;
 use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
 
@@ -26,6 +25,18 @@ class GCPClientManager
 
     /** @var array<FoldersClient|ProjectsClient|ServiceUsageClient|AnalyticsHubServiceClient> */
     private array $clients = [];
+
+    public const DEFAULT_RETRY_SETTINGS =
+        [
+            // try max 3 times
+            'retries' => 3,
+            // multiplicator of backoff time between runs. First = $initial_delay ; second $previousDelay * $factor
+            'factor' => 1.1,
+            // by default, we know that we have to wait 60 seconds
+            'initial_delay' => 60,
+            // randomize backoff time +/- 10%
+            'jitter' => 0.1,
+        ];
 
     /**
      * @throws \Google\ApiCore\ValidationException
@@ -66,6 +77,7 @@ class GCPClientManager
     {
         $client = new Google_Client([
             'credentials' => CredentialsHelper::getCredentialsArray($credentials),
+            'retry' => self::DEFAULT_RETRY_SETTINGS,
         ]);
         $client->setScopes(self::SCOPES_CLOUD_PLATFORM);
 
@@ -77,6 +89,7 @@ class GCPClientManager
     {
         $client = new Google_Client([
             'credentials' => CredentialsHelper::getCredentialsArray($credentials),
+            'retry' => self::DEFAULT_RETRY_SETTINGS,
         ]);
         $client->setScopes(self::SCOPES_CLOUD_PLATFORM);
 

--- a/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
+++ b/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageDriver\FunctionalTests\UseCase\Workspace;
+
+use Google\Cloud\ResourceManager\V3\Project;
+use Google\Cloud\ResourceManager\V3\ProjectsClient;
+use Google\Service\Exception;
+use Google\Service\Iam;
+use Google_Service_Iam_CreateServiceAccountRequest;
+use Keboola\StorageDriver\BigQuery\GCPClientManager;
+use Keboola\StorageDriver\BigQuery\NameGenerator;
+use Keboola\StorageDriver\FunctionalTests\BaseCase;
+use Keboola\StorageDriver\Shared\Driver\Exception\Exception as CommonDriverException;
+
+class ServiceAccountRetryTest extends BaseCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cleanTestProject();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->cleanTestProject();
+    }
+
+    public function testCreateManyServiceACounts(): void
+    {
+        $credentials = $this->getCredentials();
+        $projectsClient = $this->clientManager->getProjectClient($credentials);
+        $iamClient = $this->clientManager->getIamClient($credentials);
+
+        $stackPrefix = (string) getenv('BQ_STACK_PREFIX');
+        $folderId = (string) getenv('BQ_FOLDER_ID');
+
+        $nameGenerator = new NameGenerator($stackPrefix);
+
+        $projectId = $nameGenerator->createProjectId('-retry-' . time());
+
+        $projectCreateResult = $this->createProject($projectsClient, $folderId, $projectId);
+        $projectName = $projectCreateResult->getName();
+
+        $tooManyRequestsTested = false;
+        $namePrefix = 'sa-' . time();
+        // using very low initial delay to test that the retry will fail. catching the exception will happen later
+        $iamClient->getClient()->setConfig(
+            'retry',
+            ['retries' => 3, 'factor' => 1.1, 'initial_delay' => 5, 'jitter' => 0.1]
+        );
+        for ($i = 1; $i < 10; $i++) {
+            $projectServiceAccountId = $nameGenerator->createProjectServiceAccountId($namePrefix . '-' . $i);
+            try {
+                $this->createServiceAccount($iamClient, $projectServiceAccountId, $projectName);
+            } catch (Exception $e) {
+                $this->assertEquals(429, $e->getCode());
+                $tooManyRequestsTested = true;
+                break;
+            }
+        }
+        if (!$tooManyRequestsTested) {
+            $this->fail('Too many requests not tested');
+        }
+
+        // using default retry setting to test that the retry will succeed
+        $iamClient->getClient()->setConfig('retry', GCPClientManager::DEFAULT_RETRY_SETTINGS);
+        $namePrefix = 'sa-' . time();
+        for ($i = 1; $i < 10; $i++) {
+            $projectServiceAccountId = $nameGenerator->createProjectServiceAccountId($namePrefix . '-' . $i);
+            try {
+                $this->createServiceAccount($iamClient, $projectServiceAccountId, $projectName);
+            } catch (Exception $e) {
+                $this->assertEquals(429, $e->getCode());
+                $this->fail('This should not happen');
+            }
+        }
+    }
+
+    private function createServiceAccount(Iam $iamService, string $projectServiceAccountId, string $projectName): void
+    {
+        $serviceAccountsService = $iamService->projects_serviceAccounts;
+        $createServiceAccountRequest = new Google_Service_Iam_CreateServiceAccountRequest();
+
+        $createServiceAccountRequest->setAccountId($projectServiceAccountId);
+        $serviceAccountsService->create($projectName, $createServiceAccountRequest);
+    }
+
+    // custom project creation because we need project name, should be cleaned by cleanTestProject()
+    private function createProject(ProjectsClient $projectsClient, string $folderId, string $projectId): Project
+    {
+        $project = new Project();
+
+        $project->setParent('folders/' . $folderId);
+        $project->setProjectId($projectId);
+        $project->setDisplayName($projectId);
+
+        $operationResponse = $projectsClient->createProject($project);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            /** @var Project $projectCreateResult */
+            $projectCreateResult = $operationResponse->getResult();
+        } else {
+            $error = $operationResponse->getError();
+            assert($error !== null);
+            throw new CommonDriverException($error->getMessage(), $error->getCode());
+        }
+
+        return $projectCreateResult;
+    }
+}

--- a/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
+++ b/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
@@ -28,9 +28,8 @@ class ServiceAccountRetryTest extends BaseCase
         $this->cleanTestProject();
     }
 
-    public function testCreateManyServiceAcounts(): void
+    public function skipCreateManyServiceAccounts(): void
     {
-        $this->markTestSkipped('for manual testing only');
         $credentials = $this->getCredentials();
         $projectsClient = $this->clientManager->getProjectClient($credentials);
         $iamClient = $this->clientManager->getIamClient($credentials);

--- a/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
+++ b/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
@@ -28,8 +28,9 @@ class ServiceAccountRetryTest extends BaseCase
         $this->cleanTestProject();
     }
 
-    public function testCreateManyServiceACounts(): void
+    public function testCreateManyServiceAcounts(): void
     {
+        $this->markTestSkipped('for manual testing only');
         $credentials = $this->getCredentials();
         $projectsClient = $this->clientManager->getProjectClient($credentials);
         $iamClient = $this->clientManager->getIamClient($credentials);


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/BIG-168

- vetsina klientu krome `Google_client` ma nejakou retry policy nastavenou. Kdyz se do nich prokliknes, tak je tam neco jako `'clientConfig' =>  __DIR__ . '/../resources/cloud_billing_client_config.json',`, kde ten json obsahuje nejakou retry policy na ruzne metody. Do toho jsem nechtel uplne stourat
- takze jsem ten retry pridal do `Google_client`, ktery ho nema a resi nam to problem zakladani SA
- pridal jsem i takovej zvlastni test. Je diskutabilni, zda ho tam vubec nechat, ale ty si muzes vyzkouset, jak to frci. kdyz si jeste do `Google\Task\Runner` pridas na lajnu 187 neco takoveho `echo time() . " executing #{$this->attempts} / {$this->maxAttempts} \n";` tak uvidis jak to pekne dela retry
- nastaveni `DEFAULT_RETRY_SETTINGS` mam tak nejak od oka. Vime, ze potrebujeme cekat cca 60s, takze delay je 60s, factor jsem dal jen 1.1 aby to moc exponencialne nerostlo a jitter taky malinkatej