### PR TITLE
BIG-173 dont send requirePartitionFilter if partitioning is not set

### DIFF
--- a/src/Handler/Table/Create/Helper/CreateTableMetaHelper.php
+++ b/src/Handler/Table/Create/Helper/CreateTableMetaHelper.php
@@ -75,7 +75,10 @@ final class CreateTableMetaHelper
                 ],
             ];
         }
-        $options['requirePartitionFilter'] = $meta->getRequirePartitionFilter();
+
+        if ($meta->getTimePartitioning() !== null || $meta->getRangePartitioning() !== null) {
+            $options['requirePartitionFilter'] = $meta->getRequirePartitionFilter();
+        }
 
         return $options;
     }

--- a/tests/functional/UseCase/Table/CreateDropTableTest.php
+++ b/tests/functional/UseCase/Table/CreateDropTableTest.php
@@ -223,8 +223,10 @@ class CreateDropTableTest extends BaseCase
         $this->expectExceptionMessage('Failed to create table');
         $this->createTableForPartitioning(
             (new CreateTableCommand\BigQueryTableMeta())
-                // clustering without partitioning will throw exception
-                ->setClustering((new Clustering())->setFields(['id'])),
+                // range partitioning must have range defined
+                ->setRangePartitioning((new RangePartitioning())
+                    ->setField('id')
+                    ->setRange((new RangePartitioning\Range()))),
             'range'
         );
     }

--- a/tests/unit/Table/Create/Helper/CreateTableMetaHelperTest.php
+++ b/tests/unit/Table/Create/Helper/CreateTableMetaHelperTest.php
@@ -24,6 +24,18 @@ class CreateTableMetaHelperTest extends TestCase
             [],
         ];
         $meta = new Any();
+        $meta->pack((new CreateTableCommand\BigQueryTableMeta()));
+        yield 'empty metadata' => [
+            (new CreateTableCommand())->setMeta($meta),
+            [],
+        ];
+        $meta = new Any();
+        $meta->pack((new CreateTableCommand\BigQueryTableMeta())->setRequirePartitionFilter(true));
+        yield 'partition filter without partitioning' => [
+            (new CreateTableCommand())->setMeta($meta),
+            [],
+        ];
+        $meta = new Any();
         $meta->pack((new CreateTableCommand\BigQueryTableMeta())->setTimePartitioning(
             (new TimePartitioning())
                 ->setType('DAY')


### PR DESCRIPTION
JIRA: BIG-173 

requirePartitionFilter je pokaždé false, takže sa posílal v req, problém je, že když sa pošle v req na vytvoření tabulky a není partitioning nastavený tak to skončí 400.
Connection pokaždé pošle prázdný meta objekt takže sa tam všude nastavoval requirePartitionFilter a padalo to.