### PR TITLE
BIG-167 add exception if ratelimit

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageDriver\BigQuery;
+
+use Keboola\StorageDriver\Shared\Driver\Exception\Command\TooManyRequestsException;
+use Throwable;
+
+class ExceptionHandler
+{
+    public const TOO_MANY_REQUESTS_CODES = [429, 409];
+
+    public static function handleRetryException(Throwable $e): Throwable
+    {
+        if (in_array($e->getCode(), self::TOO_MANY_REQUESTS_CODES)) {
+            return new TooManyRequestsException();
+        }
+        return $e;
+    }
+}

--- a/src/GCPClientManager.php
+++ b/src/GCPClientManager.php
@@ -73,7 +73,7 @@ class GCPClientManager
         return $client;
     }
 
-    public function getIamClient(GenericBackendCredentials $credentials): Iam
+    public function getIamClient(GenericBackendCredentials $credentials): IAMServiceWrapper
     {
         $client = new Google_Client([
             'credentials' => CredentialsHelper::getCredentialsArray($credentials),
@@ -82,7 +82,7 @@ class GCPClientManager
         $client->setScopes(self::SCOPES_CLOUD_PLATFORM);
 
         // note: the close method is not used in this client
-        return new Iam($client);
+        return new IAMServiceWrapper($client);
     }
 
     public function getCloudResourceManager(GenericBackendCredentials $credentials): Google_Service_CloudResourceManager

--- a/src/Handler/Project/Create/CreateProjectHandler.php
+++ b/src/Handler/Project/Create/CreateProjectHandler.php
@@ -115,7 +115,7 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
 
         $projectServiceAccountId = $nameGenerator->createProjectServiceAccountId($command->getProjectId());
         $iamService = $this->clientManager->getIamClient($credentials);
-        $projectServiceAccount = $iamService->createServiceAccount( $projectServiceAccountId, $projectName);
+        $projectServiceAccount = $iamService->createServiceAccount($projectServiceAccountId, $projectName);
 
         $storageManager = $this->clientManager->getStorageClient($credentials);
         $fileStorageBucket = $storageManager->bucket($fileStorageBucketName);

--- a/src/Handler/Project/Create/CreateProjectHandler.php
+++ b/src/Handler/Project/Create/CreateProjectHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\StorageDriver\BigQuery\Handler\Project\Create;
 
-use Exception as NativeException;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ValidationException;
 use Google\Cloud\BigQuery\AnalyticsHub\V1\DataExchange;
@@ -19,12 +18,10 @@ use Google_Service_CloudResourceManager_Binding;
 use Google_Service_CloudResourceManager_GetIamPolicyRequest;
 use Google_Service_CloudResourceManager_Policy;
 use Google_Service_CloudResourceManager_SetIamPolicyRequest;
-use Google_Service_Iam;
-use Google_Service_Iam_CreateServiceAccountKeyRequest;
-use Google_Service_Iam_CreateServiceAccountRequest;
 use Keboola\StorageDriver\BigQuery\GCPClientManager;
 use Keboola\StorageDriver\BigQuery\GCPServiceIds;
 use Keboola\StorageDriver\BigQuery\IAmPermissions;
+use Keboola\StorageDriver\BigQuery\IAMServiceWrapper;
 use Keboola\StorageDriver\BigQuery\NameGenerator;
 use Keboola\StorageDriver\Command\Project\CreateProjectCommand;
 use Keboola\StorageDriver\Command\Project\CreateProjectResponse;
@@ -32,7 +29,6 @@ use Keboola\StorageDriver\Contract\Driver\Command\DriverCommandHandlerInterface;
 use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
 use Keboola\StorageDriver\Shared\Driver\Exception\Exception;
 use Retry\BackOff\ExponentialBackOffPolicy;
-use Retry\Policy\CallableRetryPolicy;
 use Retry\Policy\SimpleRetryPolicy;
 use Retry\RetryProxy;
 
@@ -47,8 +43,6 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
         GCPServiceIds::CLOUD_ANALYTIC_HUB_SERVICE,
     ];
 
-    public const PRIVATE_KEY_TYPE = 'TYPE_GOOGLE_CREDENTIALS_FILE';
-    public const KEY_DATA_PROPERTY_PRIVATE_KEY = 'private_key';
 
     public GCPClientManager $clientManager;
 
@@ -120,8 +114,8 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
         $billingClient->updateProjectBillingInfo($projectName, ['projectBillingInfo' => $billingInfo]);
 
         $projectServiceAccountId = $nameGenerator->createProjectServiceAccountId($command->getProjectId());
-        $iAmClient = $this->clientManager->getIamClient($credentials);
-        $projectServiceAccount = $this->createServiceAccount($iAmClient, $projectServiceAccountId, $projectName);
+        $iamService = $this->clientManager->getIamClient($credentials);
+        $projectServiceAccount = $iamService->createServiceAccount( $projectServiceAccountId, $projectName);
 
         $storageManager = $this->clientManager->getStorageClient($credentials);
         $fileStorageBucket = $storageManager->bucket($fileStorageBucketName);
@@ -136,16 +130,12 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
         ];
         $fileStorageBucket->iam()->setPolicy($actualBucketPolicy);
 
-        $this->waitUntilServiceAccPropagate($iAmClient, $projectServiceAccount);
+        $this->waitUntilServiceAccPropagate($iamService, $projectServiceAccount);
 
         $cloudResourceManager = $this->clientManager->getCloudResourceManager($credentials);
         $this->setPermissionsToServiceAccount($cloudResourceManager, $projectName, $projectServiceAccount->getEmail());
-        $keyData = $this->createKeyFileCredentials($iAmClient, $projectServiceAccount);
 
-        $privateKey = $keyData[self::KEY_DATA_PROPERTY_PRIVATE_KEY];
-        unset($keyData[self::KEY_DATA_PROPERTY_PRIVATE_KEY]);
-        $publicPart = json_encode($keyData);
-        assert($publicPart !== false);
+        [$privateKey, $publicPart] = $iamService->createKeyFileCredentials($projectServiceAccount);
 
         $analyticHubClient = $this->clientManager->getAnalyticHubClient($credentials);
         $location = GCPClientManager::DEFAULT_LOCATION;
@@ -208,18 +198,6 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
         }
     }
 
-    private function createServiceAccount(
-        Google_Service_Iam $iamService,
-        string $projectServiceAccountId,
-        string $projectName
-    ): ServiceAccount {
-        $serviceAccountsService = $iamService->projects_serviceAccounts;
-        $createServiceAccountRequest = new Google_Service_Iam_CreateServiceAccountRequest();
-
-        $createServiceAccountRequest->setAccountId($projectServiceAccountId);
-        return $serviceAccountsService->create($projectName, $createServiceAccountRequest);
-    }
-
     private function setPermissionsToServiceAccount(
         Google_Service_CloudResourceManager $cloudResourceManagerClient,
         string $projectName,
@@ -259,26 +237,8 @@ final class CreateProjectHandler implements DriverCommandHandlerInterface
         $cloudResourceManagerClient->projects->setIamPolicy($projectName, $setIamPolicyRequest);
     }
 
-    /** @return array<string, string> */
-    private function createKeyFileCredentials(Google_Service_Iam $iamService, ServiceAccount $serviceAccount): array
-    {
-        $serviceAccKeysService = $iamService->projects_serviceAccounts_keys;
-        $createServiceAccountKeyRequest = new Google_Service_Iam_CreateServiceAccountKeyRequest();
-        $createServiceAccountKeyRequest->setPrivateKeyType(self::PRIVATE_KEY_TYPE);
-        $key = $serviceAccKeysService->create($serviceAccount->getName(), $createServiceAccountKeyRequest);
-
-        $json = base64_decode($key->getPrivateKeyData());
-        $keyData = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
-
-        if (!is_array($keyData)) {
-            throw new NativeException('Project key credentials missing.');
-        }
-
-        return $keyData;
-    }
-
     private function waitUntilServiceAccPropagate(
-        Google_Service_Iam $iAmClient,
+        IAMServiceWrapper $iAmClient,
         ServiceAccount $projectServiceAccount
     ): void {
         $retryPolicy = new SimpleRetryPolicy(5);

--- a/src/IAMServiceWrapper.php
+++ b/src/IAMServiceWrapper.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Keboola\StorageDriver\BigQuery;
 
+use Exception as NativeException;
 use Google\Exception as GoogleClientException;
 use Google\Service\Iam;
 use Google\Service\Iam\ServiceAccount;
 use Google_Service_Iam_CreateServiceAccountKeyRequest;
 use Google_Service_Iam_CreateServiceAccountRequest;
-use Exception as NativeException;
 
 class IAMServiceWrapper extends Iam
 {
@@ -20,8 +20,7 @@ class IAMServiceWrapper extends Iam
     public function createServiceAccount(
         string $projectServiceAccountId,
         string $projectName
-    ): ServiceAccount
-    {
+    ): ServiceAccount {
         $serviceAccountsService = $this->projects_serviceAccounts;
         $createServiceAccountRequest = new Google_Service_Iam_CreateServiceAccountRequest();
 
@@ -33,10 +32,12 @@ class IAMServiceWrapper extends Iam
         }
     }
 
+    /**
+     * @return string[]
+     */
     public function createKeyFileCredentials(
         ServiceAccount $serviceAccount
-    ): array
-    {
+    ): array {
         $serviceAccKeysService = $this->projects_serviceAccounts_keys;
 
         $createServiceAccountKeyRequest = new Google_Service_Iam_CreateServiceAccountKeyRequest();

--- a/src/IAMServiceWrapper.php
+++ b/src/IAMServiceWrapper.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Keboola\StorageDriver\BigQuery;
+
+use Google\Service\Iam;
+use Google\Service\Iam\ServiceAccount;
+use Google_Service_Iam_CreateServiceAccountKeyRequest;
+use Google_Service_Iam_CreateServiceAccountRequest;
+use Keboola\StorageDriver\Shared\Driver\Exception\Command\TooManyRequestsException;
+use Exception as NativeException;
+
+class IAMServiceWrapper extends Iam
+{
+
+    public const PRIVATE_KEY_TYPE = 'TYPE_GOOGLE_CREDENTIALS_FILE';
+    public const KEY_DATA_PROPERTY_PRIVATE_KEY = 'private_key';
+
+    public function createServiceAccount(
+        string $projectServiceAccountId,
+        string $projectName
+    ): ServiceAccount
+    {
+        $serviceAccountsService = $this->projects_serviceAccounts;
+        $createServiceAccountRequest = new Google_Service_Iam_CreateServiceAccountRequest();
+
+        $createServiceAccountRequest->setAccountId($projectServiceAccountId);
+        try {
+            return $serviceAccountsService->create($projectName, $createServiceAccountRequest);
+        } catch (\Google\Exception $e) {
+            if ($e->getCode() === 429) {
+                throw new TooManyRequestsException();
+            }
+            throw $e;
+        }
+    }
+
+    public function createKeyFileCredentials(
+        ServiceAccount $serviceAccount
+    ): array
+    {
+        $serviceAccKeysService = $this->projects_serviceAccounts_keys;
+
+        $createServiceAccountKeyRequest = new Google_Service_Iam_CreateServiceAccountKeyRequest();
+        $createServiceAccountKeyRequest->setPrivateKeyType(self::PRIVATE_KEY_TYPE);
+        try {
+            $key = $serviceAccKeysService->create($serviceAccount->getName(), $createServiceAccountKeyRequest);
+        } catch (\Google\Exception $e) {
+            if ($e->getCode() === 429) {
+                throw new TooManyRequestsException();
+            }
+            throw $e;
+        }
+
+        $json = base64_decode($key->getPrivateKeyData());
+        $keyData = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($keyData)) {
+            throw new NativeException('Project key credentials missing.');
+        }
+
+        $privateKey = $keyData[self::KEY_DATA_PROPERTY_PRIVATE_KEY];
+        unset($keyData[self::KEY_DATA_PROPERTY_PRIVATE_KEY]);
+        $publicPart = json_encode($keyData);
+        assert($publicPart !== false);
+
+        return [$privateKey, $publicPart];
+    }
+}

--- a/tests/functional/BaseCase.php
+++ b/tests/functional/BaseCase.php
@@ -15,7 +15,6 @@ use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Service\CloudResourceManager\Project;
 use Google\Service\Exception as GoogleServiceException;
-use Google_Service_Iam;
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\StorageDriver\BigQuery\CredentialsHelper;
 use Keboola\StorageDriver\BigQuery\GCPClientManager;
@@ -23,6 +22,7 @@ use Keboola\StorageDriver\BigQuery\Handler\Bucket\Create\CreateBucketHandler;
 use Keboola\StorageDriver\BigQuery\Handler\Project\Create\CreateProjectHandler;
 use Keboola\StorageDriver\BigQuery\Handler\Table\Create\CreateTableHandler;
 use Keboola\StorageDriver\BigQuery\Handler\Workspace\Create\CreateWorkspaceHandler;
+use Keboola\StorageDriver\BigQuery\IAMServiceWrapper;
 use Keboola\StorageDriver\BigQuery\NameGenerator;
 use Keboola\StorageDriver\Command\Bucket\CreateBucketCommand;
 use Keboola\StorageDriver\Command\Bucket\CreateBucketResponse;
@@ -586,7 +586,7 @@ class BaseCase extends TestCase
         return $projectBqClient->dataset($datasetName)->exists();
     }
 
-    public function isUserExists(Google_Service_Iam $iamService, string $workspacePublicCredentialsPart): bool
+    public function isUserExists(IAMServiceWrapper $iamService, string $workspacePublicCredentialsPart): bool
     {
         /** @var array<string, string> $credentialsArr */
         $credentialsArr = (array) json_decode($workspacePublicCredentialsPart, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
+++ b/tests/functional/UseCase/Workspace/ServiceAccountRetryTest.php
@@ -56,7 +56,7 @@ class ServiceAccountRetryTest extends BaseCase
         for ($i = 1; $i < 10; $i++) {
             $projectServiceAccountId = $nameGenerator->createProjectServiceAccountId($namePrefix . '-' . $i);
             try {
-                $iamClient->createServiceAccount($projectServiceAccountId,$projectName);
+                $iamClient->createServiceAccount($projectServiceAccountId, $projectName);
             } catch (TooManyRequestsException $e) {
                 $tooManyRequestsTested = true;
                 break;


### PR DESCRIPTION
Jira: BIG-167

pridal jsem wrapper nad Iam clientem, ktery pripadne vyhodi vlastni exception. ten rollback jsem zjisitl, ze by mel stacit jen u createProject. 

`createKeyFileCredentials` jsem udelal, aby vlastne byla vsude pouzity ten novy wrapper. rollback pro jeho failu jsem nedelal, protoze zda se, ze nas to zatim netrapi. Jestli zacne, tak to bude na nejakej vetsi refactoring a sjednoceni tech retry politik a rollbacku (napadlo strkat kazdej resource do zasobniku vcetne callbacku pro vlastni rollback)