### PR TITLE
BIG-123 hide other ws for ws

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
         "keboola/storage-driver-common": "^6.8",
-        "google/cloud-resource-manager": "^0.8.2",
+        "google/cloud-resource-manager": "^0.6.1",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.12.1",
         "google/cloud-bigquery": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "google/protobuf": "^3.21",
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
-        "google/cloud-resource-manager": "^0.3.5",
         "keboola/storage-driver-common": "^6.8",
+        "google/cloud-resource-manager": "^0.8.2",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.12.1",
         "google/cloud-bigquery": "^1.23",
@@ -49,7 +49,7 @@
         "keboola/coding-standard": "^15.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "symfony/finder": "^5.4",
-        "keboola/phpunit-retry-annotations": "^0.4.0",
+        "keboola/phpunit-retry-annotations": "^0.5.0",
         "brianium/paratest": "^6.10",
         "symfony/lock": "^6.3"
     },

--- a/src/Handler/Workspace/Create/CreateWorkspaceHandler.php
+++ b/src/Handler/Workspace/Create/CreateWorkspaceHandler.php
@@ -7,6 +7,7 @@ namespace Keboola\StorageDriver\BigQuery\Handler\Workspace\Create;
 use Google\Protobuf\Internal\Message;
 use Google\Service\CloudResourceManager\Binding;
 use Google\Service\CloudResourceManager\GetIamPolicyRequest;
+use Google\Service\CloudResourceManager\GetPolicyOptions;
 use Google\Service\CloudResourceManager\Policy;
 use Google\Service\CloudResourceManager\SetIamPolicyRequest;
 use Google\Service\Iam\ServiceAccount;
@@ -134,7 +135,10 @@ final class CreateWorkspaceHandler extends BaseHandler
 
         $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAcc): void {
             $getIamPolicyRequest = new GetIamPolicyRequest();
-            $actualPolicy = $cloudResourceManager->projects->getIamPolicy($projectName, $getIamPolicyRequest, []);
+            $option = new GetPolicyOptions();
+            $option->setRequestedPolicyVersion(Helper::REQUESTED_POLICY_VERSION);
+            $getIamPolicyRequest->setOptions($option);
+            $actualPolicy = $cloudResourceManager->projects->getIamPolicy($projectName, $getIamPolicyRequest);
             $finalBinding[] = $actualPolicy->getBindings();
 
             foreach (self::IAM_WORKSPACE_SERVICE_ACCOUNT_ROLES as $role) {
@@ -145,7 +149,7 @@ final class CreateWorkspaceHandler extends BaseHandler
             }
 
             $policy = new Policy();
-            $policy->setVersion($actualPolicy->getVersion());
+            $policy->setVersion(Helper::REQUESTED_POLICY_VERSION);
             $policy->setEtag($actualPolicy->getEtag());
             $policy->setBindings($finalBinding);
             $setIamPolicyRequest = new SetIamPolicyRequest();

--- a/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
@@ -90,8 +90,10 @@ class CreateDropWorkspaceTest extends BaseCase
         /** @var array<string, string> $datasets */
         $datasets = $bqClient->runQuery($bqClient->query(sprintf(
         /** @lang BigQuery */
-            'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA;',
+            'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA WHERE `schema_name` IN (%s,%s) ;',
             BigqueryQuote::quoteSingleIdentifier($projectId),
+            BigqueryQuote::quote(strtoupper($wsResponse1->getWorkspaceObjectName())),
+            BigqueryQuote::quote(strtoupper($wsResponse2->getWorkspaceObjectName())),
         )));
 
         // two workspace datasets

--- a/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
@@ -176,6 +176,7 @@ class CreateDropWorkspaceTest extends BaseCase
 
         $ws2BqClient = $this->clientManager->getBigQueryClient($this->testRunId, $wsCredentials2);
 
+        // test WS2 can't read from other workspaces
         try {
             $ws2BqClient->runQuery($ws2BqClient->query(sprintf(
                 'SELECT * FROM %s.`testTable`;',
@@ -187,6 +188,7 @@ class CreateDropWorkspaceTest extends BaseCase
             $this->assertStringContainsString('User does not have permission to query table', $e->getMessage());
         }
 
+        // test WS2 can't write into other workspaces
         try {
             $ws2BqClient->runQuery($ws2BqClient->query(sprintf(
                 'CREATE TABLE %s.`testTable` (`id` INTEGER);',

--- a/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\StorageDriver\FunctionalTests\UseCase\Workspace;
 
+use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\Core\Exception\ServiceException;
 use Google\Protobuf\Any;
 use Google\Protobuf\Internal\GPBType;
@@ -175,6 +176,13 @@ class CreateDropWorkspaceTest extends BaseCase
         )));
 
         $ws2BqClient = $this->clientManager->getBigQueryClient($this->testRunId, $wsCredentials2);
+        // test WS2 can see only own WS dataset and bucket dataset via RO
+        $actualDatasetsInWs2 = [];
+        /** @var Dataset $dataset */
+        foreach ($ws2BqClient->datasets() as $dataset) {
+            $actualDatasetsInWs2[] = $dataset->info()['datasetReference']['datasetId'];
+        }
+        $this->assertNotContains($wsResponse1->getWorkspaceObjectName(), $actualDatasetsInWs2);
 
         // test WS2 can't read from other workspaces
         try {

--- a/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
@@ -63,6 +63,12 @@ class CreateDropWorkspaceTest extends BaseCase
             $wsCredentials1,
             $wsResponse1,
         ] = $this->createTestWorkspace($this->projectCredentials, $this->projectResponse, $this->projects[0][2]);
+
+        [
+            $wsCredentials2,
+            $wsResponse2,
+        ] = $this->createTestWorkspace($this->projectCredentials, $this->projectResponse, $this->projects[0][2]);
+
         $this->assertInstanceOf(GenericBackendCredentials::class, $wsCredentials1);
         $this->assertInstanceOf(CreateWorkspaceResponse::class, $wsResponse1);
 
@@ -84,12 +90,12 @@ class CreateDropWorkspaceTest extends BaseCase
         /** @var array<string, string> $datasets */
         $datasets = $bqClient->runQuery($bqClient->query(sprintf(
         /** @lang BigQuery */
-            'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA WHERE `schema_name` = %s ;',
+            'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA;',
             BigqueryQuote::quoteSingleIdentifier($projectId),
-            BigqueryQuote::quote(strtoupper($response->getWorkspaceObjectName())),
         )));
 
-        $this->assertCount(1, $datasets);
+        // two workspace datasets
+        $this->assertCount(2, $datasets);
 
         // test ws service acc is owner of ws dataset
         $workspaceDataset = $bqClient->dataset($wsResponse1->getWorkspaceObjectName())->info();


### PR DESCRIPTION
Jira: BIG-123
Connection PR: https://github.com/keboola/connection/pull/4916
SAPI PR: XXX

---
cez 
```
SELECT schema_name FROM PROJECT_ID.`region-REGION`.INFORMATION_SCHEMA.SCHEMATA;
```
Si tie WS datasety vylistujem, ale nemoze
<img width="559" alt="Screenshot 2024-03-22 at 15 43 15" src="https://github.com/keboola/php-storage-driver-bigquery/assets/6448364/6aec81e1-19da-4fc2-afda-1a375b7860b1">
m s nimi nic robit. V dataGripe pak vidim len moj WS plus readOnly buckety
