### PR TITLE
Big 245 fix creating job query

### DIFF
--- a/src/BigQueryClientWrapper.php
+++ b/src/BigQueryClientWrapper.php
@@ -35,6 +35,9 @@ class BigQueryClientWrapper extends BigQueryClient
         return parent::runQuery($query, $options);
     }
 
+    // Execute query and wait for it to finish
+    // Is recommended utilizing BigQueryClient::startQuery()
+    // as it provides better mechanisms for fine grained control over result polling.
     public function executeQuery(QueryJobConfiguration $query): QueryResults
     {
         if ($this->runId !== '') {

--- a/src/GCPClientManager.php
+++ b/src/GCPClientManager.php
@@ -134,7 +134,7 @@ class GCPClientManager
      * @throws CredentialsMetaRequiredException
      * @throws \JsonException
      */
-    public function getBigQueryClient(string $runId, GenericBackendCredentials $credentials): BigQueryClient
+    public function getBigQueryClient(string $runId, GenericBackendCredentials $credentials): BigQueryClientWrapper
     {
         $credentialsMeta = CredentialsHelper::getBigQueryCredentialsMeta($credentials);
 

--- a/src/Handler/Table/Alter/AddColumnHandler.php
+++ b/src/Handler/Table/Alter/AddColumnHandler.php
@@ -78,7 +78,7 @@ final class AddColumnHandler extends BaseHandler
             $columnDefinition,
         );
 
-        $bqClient->runQuery($bqClient->query($createTableSql));
+        $bqClient->executeQuery($bqClient->query($createTableSql));
 
         return (new ObjectInfoResponse())
             ->setPath($command->getPath())

--- a/src/Handler/Table/Alter/AlterColumnHandler.php
+++ b/src/Handler/Table/Alter/AlterColumnHandler.php
@@ -91,7 +91,7 @@ final class AlterColumnHandler extends BaseHandler
 
         foreach ($alterColumnCommands as $operation => $sqlCommand) {
             try {
-                $bqClient->runQuery($bqClient->query($sqlCommand));
+                $bqClient->executeQuery($bqClient->query($sqlCommand));
                 // logging info to add it to error message as partial success of the job
                 $this->userLogger->info($operation);
             } catch (JobException|BadRequestException $e) {

--- a/src/Handler/Table/Alter/DeleteTableRowsHandler.php
+++ b/src/Handler/Table/Alter/DeleteTableRowsHandler.php
@@ -91,7 +91,7 @@ final class DeleteTableRowsHandler extends BaseHandler
         $queryDataBindings = $queryData->getBindings();
         $initialRowsCount = $ref->getRowsCount();
 
-        $bqClient->runQuery(
+        $bqClient->executeQuery(
             $bqClient->query($queryData->getQuery())
                 ->parameters($queryDataBindings),
         );

--- a/src/Handler/Table/Alter/DropColumnHandler.php
+++ b/src/Handler/Table/Alter/DropColumnHandler.php
@@ -56,7 +56,7 @@ final class DropColumnHandler extends BaseHandler
             $command->getColumnName(),
         );
 
-        $bqClient->runQuery($bqClient->query($dropColumnSql));
+        $bqClient->executeQuery($bqClient->query($dropColumnSql));
 
         return null;
     }

--- a/src/Handler/Table/Create/CreateTableFromTimeTravelHandler.php
+++ b/src/Handler/Table/Create/CreateTableFromTimeTravelHandler.php
@@ -84,7 +84,7 @@ final class CreateTableFromTimeTravelHandler extends BaseHandler
         );
 
         try {
-            $bqClient->runQuery($bqClient->query($query));
+            $bqClient->executeQuery($bqClient->query($query));
         } catch (NotFoundException $e) {
             throw new ObjectNotFoundException($sourceTableName);
         }

--- a/src/Handler/Table/Import/ImportTableFromFileHandler.php
+++ b/src/Handler/Table/Import/ImportTableFromFileHandler.php
@@ -126,7 +126,7 @@ final class ImportTableFromFileHandler extends BaseHandler
             $query = $bqClient->query(
                 $qb->getCreateTableCommandFromDefinition($stagingTable),
             );
-            $bqClient->runQuery($query);
+            $bqClient->executeQuery($query);
 
             // load to staging table
             $toStageImporter = new ToStageImporter($bqClient);
@@ -155,7 +155,7 @@ final class ImportTableFromFileHandler extends BaseHandler
                         $stagingTable->getSchemaName(),
                         $stagingTable->getTableName(),
                     );
-                    $bqClient->runQuery($bqClient->query($query));
+                    $bqClient->executeQuery($bqClient->query($query));
                 } catch (Throwable $e) {
                     // ignore
                 }

--- a/src/Handler/Table/Preview/PreviewTableHandler.php
+++ b/src/Handler/Table/Preview/PreviewTableHandler.php
@@ -98,7 +98,7 @@ final class PreviewTableHandler extends BaseHandler
 
         // select table
         try {
-            $result = $bqClient->runQuery(
+            $result = $bqClient->executeQuery(
                 $bqClient->query($queryData->getQuery())
                     ->parameters($queryDataBindings),
             );

--- a/src/Handler/Workspace/DropObject/DropWorkspaceObjectHandler.php
+++ b/src/Handler/Workspace/DropObject/DropWorkspaceObjectHandler.php
@@ -59,7 +59,7 @@ final class DropWorkspaceObjectHandler extends BaseHandler
             return null;
         }
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'DROP TABLE %s.%s;',
             BigqueryQuote::quoteSingleIdentifier($command->getWorkspaceObjectName()),
             BigqueryQuote::quoteSingleIdentifier($command->getObjectNameToDrop()),

--- a/tests/functional/BaseCase.php
+++ b/tests/functional/BaseCase.php
@@ -607,7 +607,7 @@ class BaseCase extends TestCase
     ): void {
         $bqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
         if ($truncate) {
-            $bqClient->runQuery($bqClient->query(sprintf(
+            $bqClient->executeQuery($bqClient->query(sprintf(
                 'TRUNCATE TABLE %s.%s',
                 BigqueryQuote::quoteSingleIdentifier($databaseName),
                 BigqueryQuote::quoteSingleIdentifier($tableName),
@@ -626,7 +626,7 @@ class BaseCase extends TestCase
                 $insertGroup['columns'],
                 implode(",\n", $insert),
             );
-            $bqClient->runQuery($bqClient->query($insertSql));
+            $bqClient->executeQuery($bqClient->query($insertSql));
         }
     }
 

--- a/tests/functional/UseCase/Bucket/GrantRevokeBucketAccessToReadOnlyRoleTest.php
+++ b/tests/functional/UseCase/Bucket/GrantRevokeBucketAccessToReadOnlyRoleTest.php
@@ -168,7 +168,7 @@ class GrantRevokeBucketAccessToReadOnlyRoleTest extends BaseCase
         $this->assertCount(1, $registeredTables);
 
         // And I can get rows from external table
-        $result = $mainBqClient->runQuery(
+        $result = $mainBqClient->executeQuery(
             $mainBqClient->query('SELECT * FROM `123_test_external`.`' . $externalTableName . '`'),
         );
         $this->assertCount(3, $result);
@@ -211,7 +211,7 @@ class GrantRevokeBucketAccessToReadOnlyRoleTest extends BaseCase
         );
 
         // And I can get rows from external table
-        $result = $mainBqClient->runQuery(
+        $result = $mainBqClient->executeQuery(
             $mainBqClient->query('SELECT * FROM `123_test_external`.`' . $externalTableName . '`'),
         );
         $this->assertCount(4, $result);
@@ -254,7 +254,7 @@ class GrantRevokeBucketAccessToReadOnlyRoleTest extends BaseCase
         );
 
         try {
-            $mainBqClient->runQuery(
+            $mainBqClient->executeQuery(
                 $mainBqClient->query('SELECT * FROM `123_test_external`.`' . $externalTableName . '`'),
             );
             $this->fail('Should not be able to get data from external table after revoke access.');

--- a/tests/functional/UseCase/Bucket/ShareLinkBucketTest.php
+++ b/tests/functional/UseCase/Bucket/ShareLinkBucketTest.php
@@ -82,7 +82,7 @@ class ShareLinkBucketTest extends BaseCase
             [],
             new RuntimeOptions(['runId' => $this->testRunId]),
         );
-        $sourceBqClient->runQuery($sourceBqClient->query(sprintf(
+        $sourceBqClient->executeQuery($sourceBqClient->query(sprintf(
             'INSERT INTO %s.%s (`ID`) VALUES (1)',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier(self::TESTTABLE_BEFORE_NAME),
@@ -175,7 +175,7 @@ class ShareLinkBucketTest extends BaseCase
             new RuntimeOptions(['runId' => $this->testRunId]),
         );
         // check that there is no need to re-share or whatever
-        $sourceBqClient->runQuery($sourceBqClient->query(sprintf(
+        $sourceBqClient->executeQuery($sourceBqClient->query(sprintf(
             'INSERT INTO %s.%s (`ID`) VALUES (1)',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier(self::TESTTABLE_AFTER_NAME),
@@ -327,7 +327,7 @@ class ShareLinkBucketTest extends BaseCase
             new RuntimeOptions(['runId' => $this->testRunId]),
         );
         // check that there is no need to re-share or whatever
-        $sourceBqClient->runQuery($sourceBqClient->query(sprintf(
+        $sourceBqClient->executeQuery($sourceBqClient->query(sprintf(
             'INSERT INTO %s.%s (`ID`) VALUES (1)',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier(self::TESTTABLE_AFTER_NAME),

--- a/tests/functional/UseCase/Info/ObjectInfoTest.php
+++ b/tests/functional/UseCase/Info/ObjectInfoTest.php
@@ -50,7 +50,7 @@ class ObjectInfoTest extends BaseCase
             $this->getTestHash(),
         );
         $bqClient = $this->clientManager->getBigQueryClient($this->testRunId, $this->projectCredentials);
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE VIEW %s.`bucket_view1` AS '
             . 'SELECT * FROM %s.%s;',
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
@@ -338,21 +338,21 @@ class ObjectInfoTest extends BaseCase
     private function createObjectsInSchema(): void
     {
         $bqClient = $this->clientManager->getBigQueryClient($this->testRunId, $this->projectCredentials);
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE MATERIALIZED VIEW %s.`materialized_view` AS '
             . 'SELECT * FROM %s.%s;',
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
             BigqueryQuote::quoteSingleIdentifier($this->getTestHash()),
         )));
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE SNAPSHOT TABLE %s.`snapshot` CLONE %s.%s '
             . 'OPTIONS ( expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR));',
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
             BigqueryQuote::quoteSingleIdentifier($this->getTestHash()),
         )));
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             "CREATE OR REPLACE EXTERNAL TABLE %s.externalTable OPTIONS (format = 'CSV',uris = [%s]);",
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
             BigqueryQuote::quote('gs://' . getenv('BQ_BUCKET_NAME') . '/import/a_b_c-3row.csv'),
@@ -361,7 +361,7 @@ class ObjectInfoTest extends BaseCase
         // simulate user interaction, he creates connection to external bucket manually in console.google.com
         $connection = $this->prepareConnectionForExternalBucket();
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             "CREATE OR REPLACE EXTERNAL TABLE %s.externalTableWithConnection 
             WITH CONNECTION %s 
             OPTIONS (format = 'CSV',uris = [%s]);",
@@ -370,7 +370,7 @@ class ObjectInfoTest extends BaseCase
             BigqueryQuote::quote('gs://' . getenv('BQ_BUCKET_NAME') . '/import/a_b_c-3row.csv'),
         )));
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 CREATE TABLE
   %s.partitionedTable (transaction_id INT64)
@@ -383,14 +383,14 @@ SQL,
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
         )));
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 INSERT INTO %s.partitionedTable (transaction_id) VALUES (1)
 SQL,
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
         )));
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 CREATE VIEW %s.partitionedView AS ( 
     SELECT
@@ -403,7 +403,7 @@ SQL,
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
         )));
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 CREATE TABLE
   %s.table2 (transaction_id INT64)
@@ -411,14 +411,14 @@ SQL,
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
         )));
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 INSERT INTO %s.table2 (transaction_id) VALUES (1)
 SQL,
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
         )));
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 CREATE VIEW %s.table2View AS ( 
     SELECT
@@ -430,7 +430,7 @@ SQL,
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
             BigqueryQuote::quoteSingleIdentifier($this->bucketResponse->getCreateBucketObjectName()),
         )));
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */<<<SQL
 DROP TABLE %s.table2
 SQL,

--- a/tests/functional/UseCase/Table/AddDropColumnTest.php
+++ b/tests/functional/UseCase/Table/AddDropColumnTest.php
@@ -65,7 +65,7 @@ class AddDropColumnTest extends BaseCase
             $tableDef->getColumnsDefinitions(),
             $tableDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $path = new RepeatedField(GPBType::STRING);
         $path[] = $bucketDatabaseName;
@@ -134,7 +134,7 @@ class AddDropColumnTest extends BaseCase
             $tableDef->getColumnsDefinitions(),
             $tableDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $path = new RepeatedField(GPBType::STRING);
         $path[] = $bucketDatabaseName;

--- a/tests/functional/UseCase/Table/AlterColumnTest.php
+++ b/tests/functional/UseCase/Table/AlterColumnTest.php
@@ -433,6 +433,6 @@ class AlterColumnTest extends BaseCase
             $tableDef->getColumnsDefinitions(),
             $tableDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
     }
 }

--- a/tests/functional/UseCase/Table/CreateTableFromTimeTravelTest.php
+++ b/tests/functional/UseCase/Table/CreateTableFromTimeTravelTest.php
@@ -10,6 +10,7 @@ use Google\Cloud\Core\Exception\BadRequestException;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
 use Keboola\Datatype\Definition\Bigquery;
+use Keboola\StorageDriver\BigQuery\BigQueryClientWrapper;
 use Keboola\StorageDriver\BigQuery\Handler\Table\Create\CreateTableFromTimeTravelHandler;
 use Keboola\StorageDriver\Command\Bucket\CreateBucketResponse;
 use Keboola\StorageDriver\Command\Common\RuntimeOptions;
@@ -59,7 +60,7 @@ class CreateTableFromTimeTravelTest extends BaseCase
             $insert[] = sprintf('(%s)', implode(',', $i));
         }
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -145,7 +146,7 @@ class CreateTableFromTimeTravelTest extends BaseCase
         );
 
         $bqClient = $this->clientManager->getBigQueryClient($this->testRunId, $this->projectCredentials);
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $cmd = new CreateTableFromTimeTravelCommand();
         $path = new RepeatedField(GPBType::STRING);
@@ -328,7 +329,7 @@ class CreateTableFromTimeTravelTest extends BaseCase
     }
 
     private function initTestTableAndImportBaseData(
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
         string $bucketDatasetName,
         string $sourceTableName,
     ): void {
@@ -359,12 +360,12 @@ class CreateTableFromTimeTravelTest extends BaseCase
             $tableSourceDef->getColumnsDefinitions(),
             [], //<-- dont create primary keys allow duplicates
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', '1', '3'], ['2', '2', '2'], ['3', '2', '3'], ['4', '4', '4']] as $i) {
             $insert[] = sprintf('(%s)', implode(',', $i));
         }
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),

--- a/tests/functional/UseCase/Table/Export/ExportTableToFileTest.php
+++ b/tests/functional/UseCase/Table/Export/ExportTableToFileTest.php
@@ -14,6 +14,7 @@ use Keboola\CsvOptions\CsvOptions;
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\StorageDriver\Backend\BigQuery\Clustering;
 use Keboola\StorageDriver\Backend\BigQuery\RangePartitioning;
+use Keboola\StorageDriver\BigQuery\BigQueryClientWrapper;
 use Keboola\StorageDriver\BigQuery\Handler\Table\BadExportFilterParametersException;
 use Keboola\StorageDriver\BigQuery\Handler\Table\Create\CreateTableHandler;
 use Keboola\StorageDriver\BigQuery\Handler\Table\Export\ColumnNotFoundException;
@@ -654,7 +655,7 @@ class ExportTableToFileTest extends BaseCase
     private function createSourceTable(
         string $databaseName,
         string $tableName,
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
     ): BigqueryTableDefinition {
         $tableDef = new BigqueryTableDefinition(
             $databaseName,
@@ -675,7 +676,7 @@ class ExportTableToFileTest extends BaseCase
             $tableDef->getColumnsDefinitions(),
             $tableDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         // init some values
         $insert = [];
@@ -687,7 +688,7 @@ class ExportTableToFileTest extends BaseCase
             $insert[] = sprintf('(%s)', implode(',', $i));
         }
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($databaseName),
             BigqueryQuote::quoteSingleIdentifier($tableName),
@@ -700,7 +701,7 @@ class ExportTableToFileTest extends BaseCase
     private function dropSourceTable(
         string $databaseName,
         string $tableName,
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
     ): void {
         $bucket = $bqClient->dataset($databaseName);
         $table = $bucket->table($tableName);
@@ -708,7 +709,7 @@ class ExportTableToFileTest extends BaseCase
             return;
         }
         $qb = new BigqueryTableQueryBuilder();
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($databaseName, $tableName),
         ));
     }
@@ -717,7 +718,7 @@ class ExportTableToFileTest extends BaseCase
      * @param string[] $sourceColumns
      */
     private function createSourceTableFromFile(
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
         string $sourceFilePath,
         string $sourceFileName,
         bool $sourceFileIsCompressed,
@@ -733,7 +734,7 @@ class ExportTableToFileTest extends BaseCase
                 $column,
             );
         }
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             sprintf(
                 'CREATE TABLE %s.%s (
                     %s

--- a/tests/functional/UseCase/Table/Import/FromFile/ImportTableFromFileTest.php
+++ b/tests/functional/UseCase/Table/Import/FromFile/ImportTableFromFileTest.php
@@ -10,6 +10,7 @@ use Google\Protobuf\Any;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
 use Keboola\CsvOptions\CsvOptions;
+use Keboola\StorageDriver\BigQuery\BigQueryClientWrapper;
 use Keboola\StorageDriver\BigQuery\Handler\Table\Import\ImportTableFromFileHandler;
 use Keboola\StorageDriver\Command\Common\RuntimeOptions;
 use Keboola\StorageDriver\Command\Table\ImportExportShared\FileFormat;
@@ -120,7 +121,7 @@ class ImportTableFromFileTest extends BaseImportTestCase
         // cleanup
         $qb = new BigqueryTableQueryBuilder();
         $sql = $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName());
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
     }
 
     public function testImportTableFromFileFullLoadWithoutDeduplication(): void
@@ -193,7 +194,7 @@ class ImportTableFromFileTest extends BaseImportTestCase
         // cleanup
         $qb = new BigqueryTableQueryBuilder();
         $sql = $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName());
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
     }
 
     /**
@@ -220,7 +221,7 @@ class ImportTableFromFileTest extends BaseImportTestCase
 
         $this->createAccountsTable($bqClient, $bucketDatabaseName, $destinationTableName);
         // init some values
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
         // phpcs:ignore
             'INSERT INTO %s.%s VALUES (\'10\',\'448810375\',\'init\',\'0\',\'1\',\'\',\'1\',\'0\',\'2012-02-20 09:34:22\',\'ddd\',\'ddd\',\'1\',\'2012-02-20 09:34:22\')',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
@@ -331,7 +332,7 @@ class ImportTableFromFileTest extends BaseImportTestCase
         // cleanup
         $qb = new BigqueryTableQueryBuilder();
         $sql = $qb->getDropTableCommand($bucketDatabaseName, $destinationTableName);
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
     }
 
     public function testImportTableFromFileWithNullValues(): void
@@ -423,15 +424,15 @@ class ImportTableFromFileTest extends BaseImportTestCase
         // cleanup
         $qb = new BigqueryTableQueryBuilder();
         $sql = $qb->getDropTableCommand($bucketDatabaseName, $destinationTableName);
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
     }
 
     protected function createAccountsTableWithNotNull(
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
         string $bucketDatabaseName,
         string $destinationTableName,
     ): void {
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE TABLE %s.%s (
                 `id` STRING(60),
                 `idTwitter` STRING(60),

--- a/tests/functional/UseCase/Table/Import/FromFile/IncrementalImportTableFromFileTest.php
+++ b/tests/functional/UseCase/Table/Import/FromFile/IncrementalImportTableFromFileTest.php
@@ -138,6 +138,6 @@ class IncrementalImportTableFromFileTest extends BaseImportTestCase
         // cleanup
         $qb = new BigqueryTableQueryBuilder();
         $sql = $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName());
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
     }
 }

--- a/tests/functional/UseCase/Table/Import/FromTable/ImportTableFromTableTest.php
+++ b/tests/functional/UseCase/Table/Import/FromTable/ImportTableFromTableTest.php
@@ -69,7 +69,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableSourceDef->getColumnsDefinitions(),
             $tableSourceDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', '1', '1'], ['2', '2', '2'], ['3', '3', '3']] as $i) {
             $quotedValues = [];
@@ -78,7 +78,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             }
             $insert[] = sprintf('(%s)', implode(',', $quotedValues));
         }
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -101,7 +101,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableDestDef->getColumnsDefinitions(),
             $tableDestDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $cmd = new TableImportFromTableCommand();
         $path = new RepeatedField(GPBType::STRING);
@@ -155,10 +155,10 @@ class ImportTableFromTableTest extends BaseImportTestCase
         $this->assertSame($ref->getRowsCount(), $response->getTableRowsCount());
 
         // cleanup
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($tableSourceDef->getSchemaName(), $tableSourceDef->getTableName()),
         ));
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName()),
         ));
     }
@@ -193,7 +193,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableSourceDef->getColumnsDefinitions(),
             $tableSourceDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', '1', '1'], ['2', '2', '2'], ['3', '3', '3']] as $i) {
             $quotedValues = [];
@@ -202,7 +202,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             }
             $insert[] = sprintf('(%s)', implode(',', $quotedValues));
         }
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -226,7 +226,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableDestDef->getColumnsDefinitions(),
             $tableDestDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $cmd = new TableImportFromTableCommand();
         $path = new RepeatedField(GPBType::STRING);
@@ -285,10 +285,10 @@ class ImportTableFromTableTest extends BaseImportTestCase
         $this->assertTimestamp($bqClient, $bucketDatabaseName, $destinationTableName);
 
         // cleanup
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($tableSourceDef->getSchemaName(), $tableSourceDef->getTableName()),
         ));
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName()),
         ));
     }
@@ -323,7 +323,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableSourceDef->getColumnsDefinitions(),
             $tableSourceDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', '1', '1'], ['2', '2', '2'], ['3', '3', '3'], ['2', '2', '2'], ['3', '3', '3']] as $i) {
             $quotedValues = [];
@@ -332,7 +332,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             }
             $insert[] = sprintf('(%s)', implode(',', $quotedValues));
         }
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -358,7 +358,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableDestDef->getColumnsDefinitions(),
             $tableDestDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $cmd = new TableImportFromTableCommand();
         $path = new RepeatedField(GPBType::STRING);
@@ -439,10 +439,10 @@ class ImportTableFromTableTest extends BaseImportTestCase
         ], $data);
 
         // cleanup
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($tableSourceDef->getSchemaName(), $tableSourceDef->getTableName()),
         ));
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName()),
         ));
     }
@@ -600,7 +600,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableSourceDef->getColumnsDefinitions(),
             $tableSourceDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         // data in source table have nulls -> should fail, because we are trying to fit null value in to required field
         foreach ([['1', '1', '1'], ['2', '2', '2'], ['3', '3', null]] as $i) {
@@ -610,7 +610,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             }
             $insert[] = sprintf('(%s)', implode(',', $quotedValues));
         }
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -634,7 +634,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableDestDef->getColumnsDefinitions(),
             $tableDestDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $cmd = new TableImportFromTableCommand();
         $path = new RepeatedField(GPBType::STRING);
@@ -687,10 +687,10 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $this->assertSame('Required field col3 cannot be null', $e->getMessage());
         } finally {
             // cleanup
-            $bqClient->runQuery($bqClient->query(
+            $bqClient->executeQuery($bqClient->query(
                 $qb->getDropTableCommand($tableSourceDef->getSchemaName(), $tableSourceDef->getTableName()),
             ));
-            $bqClient->runQuery($bqClient->query(
+            $bqClient->executeQuery($bqClient->query(
                 $qb->getDropTableCommand($tableDestDef->getSchemaName(), $tableDestDef->getTableName()),
             ));
         }
@@ -730,7 +730,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableSourceDef->getColumnsDefinitions(),
             $tableSourceDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', 'too expensive'], ['2', 'cheap'], ['3', 'way too expensive']] as $i) {
             $quotedValues = [];
@@ -739,7 +739,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             }
             $insert[] = sprintf('(%s)', implode(',', $quotedValues));
         }
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -764,7 +764,7 @@ class ImportTableFromTableTest extends BaseImportTestCase
             $tableDestDef->getColumnsDefinitions(),
             $tableDestDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
 
         $cmd = new TableImportFromTableCommand();
         $path = new RepeatedField(GPBType::STRING);

--- a/tests/functional/UseCase/Table/Import/FromTable/ImportViewCloneTest.php
+++ b/tests/functional/UseCase/Table/Import/FromTable/ImportViewCloneTest.php
@@ -9,6 +9,7 @@ use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Protobuf\Any;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
+use Keboola\StorageDriver\BigQuery\BigQueryClientWrapper;
 use Keboola\StorageDriver\BigQuery\Handler\Bucket\Link\LinkBucketHandler;
 use Keboola\StorageDriver\BigQuery\Handler\Bucket\Share\ShareBucketHandler;
 use Keboola\StorageDriver\BigQuery\Handler\Bucket\UnLink\UnLinkBucketHandler;
@@ -216,7 +217,7 @@ class ImportViewCloneTest extends BaseCase
 
         // cleanup
         if ($importType === ImportOptions\ImportType::VIEW) {
-            $bqClient->runQuery($bqClient->query(
+            $bqClient->executeQuery($bqClient->query(
                 sprintf(
                     'DROP VIEW %s.%s',
                     BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
@@ -224,7 +225,7 @@ class ImportViewCloneTest extends BaseCase
                 ),
             ));
         } else {
-            $bqClient->runQuery($bqClient->query(
+            $bqClient->executeQuery($bqClient->query(
                 $qb->getDropTableCommand(
                     $bucketDatabaseName,
                     $destinationTableName,
@@ -232,7 +233,7 @@ class ImportViewCloneTest extends BaseCase
             ));
         }
 
-        $bqClient->runQuery($bqClient->query(
+        $bqClient->executeQuery($bqClient->query(
             $qb->getDropTableCommand(
                 $bucketDatabaseName,
                 $sourceTableName,
@@ -349,7 +350,7 @@ class ImportViewCloneTest extends BaseCase
 
         // cleanup
         if ($importType === ImportOptions\ImportType::VIEW) {
-            $bqClient->runQuery($bqClient->query(
+            $bqClient->executeQuery($bqClient->query(
                 sprintf(
                     'DROP VIEW %s.%s',
                     BigqueryQuote::quoteSingleIdentifier($workspaceResponse->getWorkspaceObjectName()),
@@ -357,7 +358,7 @@ class ImportViewCloneTest extends BaseCase
                 ),
             ));
         } else {
-            $bqClient->runQuery($bqClient->query(
+            $bqClient->executeQuery($bqClient->query(
                 (new BigqueryTableQueryBuilder())->getDropTableCommand(
                     $workspaceResponse->getWorkspaceObjectName(),
                     $destinationTableName,
@@ -370,7 +371,7 @@ class ImportViewCloneTest extends BaseCase
     private function createSourceTable(
         string $bucketDatabaseName,
         string $sourceTableName,
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
     ): void {
         // create tables
         $tableSourceDef = new BigqueryTableDefinition(
@@ -391,7 +392,7 @@ class ImportViewCloneTest extends BaseCase
             $tableSourceDef->getColumnsDefinitions(),
             $tableSourceDef->getPrimaryKeysNames(),
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', '1', '1'], ['2', '2', '2'], ['3', '3', '3']] as $i) {
             $quotedValues = [];
@@ -401,7 +402,7 @@ class ImportViewCloneTest extends BaseCase
             $insert[] = sprintf('(%s)', implode(',', $quotedValues));
         }
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),
@@ -508,12 +509,12 @@ class ImportViewCloneTest extends BaseCase
      * count rows by selecting whole table
      */
     private function assertViewOrTableRowsCount(
-        BigQueryClient $bqClient,
+        BigQueryClientWrapper $bqClient,
         string $datasetName,
         string $tableName,
         int $expectedRowsCount,
     ): void {
-        $result = $bqClient->runQuery($bqClient->query(
+        $result = $bqClient->executeQuery($bqClient->query(
             sprintf(
                 'SELECT * FROM %s.%s',
                 BigqueryQuote::quoteSingleIdentifier($datasetName),

--- a/tests/functional/UseCase/Table/Import/FromTable/IncrementalImportTableFromTableTest.php
+++ b/tests/functional/UseCase/Table/Import/FromTable/IncrementalImportTableFromTableTest.php
@@ -71,13 +71,13 @@ class IncrementalImportTableFromTableTest extends BaseImportTestCase
             $tableSourceDef->getColumnsDefinitions(),
             [], //<-- dont create primary keys allow duplicates
         );
-        $bqClient->runQuery($bqClient->query($sql));
+        $bqClient->executeQuery($bqClient->query($sql));
         $insert = [];
         foreach ([['1', '1', '3'], ['2', '2', '2'], ['2', '2', '2'], ['3', '2', '3'], ['4', '4', '4']] as $i) {
             $insert[] = sprintf('(%s)', implode(',', $i));
         }
 
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'INSERT INTO %s.%s VALUES %s',
             BigqueryQuote::quoteSingleIdentifier($bucketDatabaseName),
             BigqueryQuote::quoteSingleIdentifier($sourceTableName),

--- a/tests/functional/UseCase/Workspace/ClearWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/ClearWorkspaceTest.php
@@ -41,11 +41,11 @@ class ClearWorkspaceTest extends BaseCase
         $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
 
         // create tables
-        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+        $wsBqClient->executeQuery($wsBqClient->query(sprintf(
             'CREATE TABLE %s.`testTable` (`id` INTEGER);',
             BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName()),
         )));
-        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+        $wsBqClient->executeQuery($wsBqClient->query(sprintf(
             'CREATE TABLE %s.`testTable2` (`id` INTEGER);',
             BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName()),
         )));

--- a/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/CreateDropWorkspaceTest.php
@@ -89,7 +89,7 @@ class CreateDropWorkspaceTest extends BaseCase
         $ws1BqClient = $this->clientManager->getBigQueryClient($this->testRunId, $wsCredentials1);
 
         /** @var array<string, string> $datasets */
-        $datasets = $bqClient->runQuery($bqClient->query(sprintf(
+        $datasets = $bqClient->executeQuery($bqClient->query(sprintf(
         /** @lang BigQuery */
             'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA WHERE `schema_name` IN (%s,%s) ;',
             BigqueryQuote::quoteSingleIdentifier($projectId),
@@ -154,7 +154,7 @@ class CreateDropWorkspaceTest extends BaseCase
             $this->assertStringContainsString('Access Denied: ', $e->getMessage());
         }
 
-        $result = $ws1BqClient->runQuery($ws1BqClient->query(sprintf(
+        $result = $ws1BqClient->executeQuery($ws1BqClient->query(sprintf(
             'SELECT * FROM %s.%s;',
             BigqueryQuote::quoteSingleIdentifier($bucketDatasetName->getCreateBucketObjectName()),
             BigqueryQuote::quoteSingleIdentifier($tableName),
@@ -162,13 +162,13 @@ class CreateDropWorkspaceTest extends BaseCase
 
         $this->assertCount(3, $result);
         // try to create table
-        $ws1BqClient->runQuery($ws1BqClient->query(sprintf(
+        $ws1BqClient->executeQuery($ws1BqClient->query(sprintf(
             'CREATE TABLE %s.`testTable` (`id` INTEGER);',
             BigqueryQuote::quoteSingleIdentifier($wsResponse1->getWorkspaceObjectName()),
         )));
 
         // try to create view
-        $ws1BqClient->runQuery($ws1BqClient->query(sprintf(
+        $ws1BqClient->executeQuery($ws1BqClient->query(sprintf(
             'CREATE VIEW %s.`testView` AS '
             . 'SELECT `id` FROM %s.`testTable`;',
             BigqueryQuote::quoteSingleIdentifier($wsResponse1->getWorkspaceObjectName()),
@@ -186,7 +186,7 @@ class CreateDropWorkspaceTest extends BaseCase
 
         // test WS2 can't read from other workspaces
         try {
-            $ws2BqClient->runQuery($ws2BqClient->query(sprintf(
+            $ws2BqClient->executeQuery($ws2BqClient->query(sprintf(
                 'SELECT * FROM %s.`testTable`;',
                 BigqueryQuote::quoteSingleIdentifier($wsResponse1->getWorkspaceObjectName()),
             )));
@@ -198,7 +198,7 @@ class CreateDropWorkspaceTest extends BaseCase
 
         // test WS2 can't write into other workspaces
         try {
-            $ws2BqClient->runQuery($ws2BqClient->query(sprintf(
+            $ws2BqClient->executeQuery($ws2BqClient->query(sprintf(
                 'CREATE TABLE %s.`testTable` (`id` INTEGER);',
                 BigqueryQuote::quoteSingleIdentifier($wsResponse1->getWorkspaceObjectName()),
             )));
@@ -210,13 +210,13 @@ class CreateDropWorkspaceTest extends BaseCase
         }
 
         // try to drop view
-        $ws1BqClient->runQuery($ws1BqClient->query(sprintf(
+        $ws1BqClient->executeQuery($ws1BqClient->query(sprintf(
             'DROP VIEW %s.`testView`;',
             BigqueryQuote::quoteSingleIdentifier($wsResponse1->getWorkspaceObjectName()),
         )));
 
         // try to drop table
-        $ws1BqClient->runQuery($ws1BqClient->query(sprintf(
+        $ws1BqClient->executeQuery($ws1BqClient->query(sprintf(
             'DROP TABLE %s.`testTable`;',
             BigqueryQuote::quoteSingleIdentifier($wsResponse1->getWorkspaceObjectName()),
         )));
@@ -255,7 +255,7 @@ class CreateDropWorkspaceTest extends BaseCase
             $this->assertStringContainsString('.iam.gserviceaccount.com does not exist.', $e->getMessage());
         }
 
-        $datasets = $bqClient->runQuery(
+        $datasets = $bqClient->executeQuery(
             $bqClient->query(sprintf(
                 'SELECT schema_name FROM %s.INFORMATION_SCHEMA.SCHEMATA WHERE `schema_name` = %s;',
                 BigqueryQuote::quoteSingleIdentifier($projectId),
@@ -338,7 +338,7 @@ class CreateDropWorkspaceTest extends BaseCase
         $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
 
         // create table
-        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+        $wsBqClient->executeQuery($wsBqClient->query(sprintf(
             'CREATE TABLE %s.`testTable` (`id` INTEGER);',
             BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName()),
         )));
@@ -371,7 +371,7 @@ class CreateDropWorkspaceTest extends BaseCase
         $projectId = $wsKeyData['project_id'];
         $wsServiceAccEmail = $wsKeyData['client_email'];
 
-        $datasets = $projectBqClient->runQuery($projectBqClient->query(sprintf(
+        $datasets = $projectBqClient->executeQuery($projectBqClient->query(sprintf(
             /** @lang BigQuery */
             'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA WHERE `schema_name` = %s ;',
             BigqueryQuote::quoteSingleIdentifier($projectId),
@@ -408,7 +408,7 @@ class CreateDropWorkspaceTest extends BaseCase
                 }
             });
 
-        $datasets = $projectBqClient->runQuery($projectBqClient->query(sprintf(
+        $datasets = $projectBqClient->executeQuery($projectBqClient->query(sprintf(
         /** @lang BigQuery */
             'SELECT `schema_name` FROM %s.INFORMATION_SCHEMA.SCHEMATA WHERE `schema_name` = %s ;',
             BigqueryQuote::quoteSingleIdentifier($projectId),

--- a/tests/functional/UseCase/Workspace/DropWorkspaceObjectTest.php
+++ b/tests/functional/UseCase/Workspace/DropWorkspaceObjectTest.php
@@ -40,17 +40,17 @@ class DropWorkspaceObjectTest extends BaseCase
         $bqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
 
         // create tables
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE TABLE %s.`testTable` (`id` INTEGER);',
             BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName()),
         )));
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE TABLE %s.`testTable2` (`id` INTEGER);',
             BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName()),
         )));
 
         // create view
-        $bqClient->runQuery($bqClient->query(sprintf(
+        $bqClient->executeQuery($bqClient->query(sprintf(
             'CREATE VIEW %s.`testView` AS '
             . 'SELECT `id` FROM %s.`testTable`;',
             BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName()),

--- a/tests/functional/UseCase/Workspace/ResetWorkspacePasswordTest.php
+++ b/tests/functional/UseCase/Workspace/ResetWorkspacePasswordTest.php
@@ -54,7 +54,7 @@ class ResetWorkspacePasswordTest extends BaseCase
 
         $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
         try {
-            $wsBqClient->runQuery($wsBqClient->query('SELECT 1'));
+            $wsBqClient->executeQuery($wsBqClient->query('SELECT 1'));
             $this->fail('Should fail');
         } catch (Throwable $e) {
             $this->assertInstanceOf(ServiceException::class, $e);
@@ -66,7 +66,7 @@ class ResetWorkspacePasswordTest extends BaseCase
 
         $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
         /** @var array<string, string> $result */
-        $result = $wsBqClient->runQuery(
+        $result = $wsBqClient->executeQuery(
             $wsBqClient->query('SELECT SESSION_USER() AS USER'),
         )->getIterator()->current();
 


### PR DESCRIPTION
Jira: BIG-245
Connection PR: https://github.com/keboola/connection/pull/4980
SAPI PR: XXX

---
Objavil som, ze v klientovy sa pise, ze `runQuery` by sa nemalo pouzivat na dlhe query
```
* This method is ideal for queries which return results quickly - otherwise
     * we highly recommend utilizing {@see Google\Cloud\BigQuery\BigQueryClient::startQuery()}
     * as it provides better mechanisms for fine grained control over result polling.
     *
```
https://github.com/googleapis/google-cloud-php/pull/3626/files
https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/bigquery/api/src/run_query_as_job.php

Takze som to upravil pre cely driver