### PR TITLE
CT-1698 delete table when reflection fails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "google/cloud-bigquery": "^1.23",
         "google/cloud-billing": "^1.4",
         "google/apiclient-services" : "0.282.0",
-        "keboola/table-backend-utils": ">=2.7.0",
+        "keboola/table-backend-utils": ">=2.8.0",
         "react/async": "^3.0",
         "keboola/db-import-export": ">=2.7.0",
         "symfony/polyfill-php80": "^1.26",

--- a/phpunit-retry.xml.dist
+++ b/phpunit-retry.xml.dist
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunitretry baseRetryCount="0"/>
+<phpunitretry baseRetryCount="3"/>

--- a/src/Handler/Table/Create/BadTableDefinitionException.php
+++ b/src/Handler/Table/Create/BadTableDefinitionException.php
@@ -44,13 +44,14 @@ class BadTableDefinitionException extends Exception implements NonRetryableExcep
 
     /**
      * @param array<mixed> $createTableOptions
+     * @throws self
      */
     public static function handleBadRequestException(
         BadRequestException $e,
         string $datasetName,
         string $tableName,
         array $createTableOptions,
-    ): self {
+    ): never {
         $message = $e->getMessage();
         try {
             $decodedMessage = json_decode($message, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/functional/UseCase/Bucket/GrantRevokeBucketAccessToReadOnlyRoleTest.php
+++ b/tests/functional/UseCase/Bucket/GrantRevokeBucketAccessToReadOnlyRoleTest.php
@@ -328,7 +328,7 @@ class GrantRevokeBucketAccessToReadOnlyRoleTest extends BaseCase
             );
             $this->fail('Should not be able to register bucket from another region.');
         } catch (InvalidArgumentException $e) {
-            $this->assertSame('Listing region "eu" must be the same as source dataset region "us".', $e->getMessage());
+            $this->assertSame('Listing region "eu" must be the same as linked dataset region "us".', $e->getMessage());
             $this->assertSame(3000, $e->getCode());
             $this->assertSame(false, $e->isRetryable());
         }


### PR DESCRIPTION
Jira: CT-1698
https://keboolaglobal.slack.com/archives/C055RTFCJ6M/p1724246345469389?thread_ts=1724243491.230729&cid=C055RTFCJ6M

BQClient lib has retry mechanism inside, this will ensure that table is deleted in case that reflection for some reason fails and retries will not cover it.