### PR TITLE
CT-1805 you cannot add nullable=false column

### DIFF
--- a/src/Handler/Table/Alter/AddColumnHandler.php
+++ b/src/Handler/Table/Alter/AddColumnHandler.php
@@ -50,7 +50,7 @@ final class AddColumnHandler extends BaseHandler
         assert($command->getTableName() !== '', 'AddColumnCommand.tableName is required');
         assert($column instanceof TableColumnShared, 'AddColumnCommand.columnDefinition is required');
 
-        assert($column->getNullable() === false, 'You cannot add a REQUIRED column to an existing table schema.');
+        assert($column->getNullable() === true, 'You cannot add a REQUIRED column to an existing table schema.');
         assert($column->getDefault() === '', 'You cannot add a DEFAULT to column an existing table schema.');
         $bqClient = $this->clientManager->getBigQueryClient($runtimeOptions->getRunId(), $credentials);
 

--- a/tests/functional/UseCase/Table/AddDropColumnTest.php
+++ b/tests/functional/UseCase/Table/AddDropColumnTest.php
@@ -76,7 +76,8 @@ class AddDropColumnTest extends BaseCase
             ->setColumnDefinition(
                 (new TableColumnShared())
                     ->setName('newCol')
-                    ->setType(Bigquery::TYPE_BIGINT),
+                    ->setType(Bigquery::TYPE_BIGINT)
+                    ->setNullable(true),
             );
         $handler = new AddColumnHandler($this->clientManager);
         $handler->setInternalLogger($this->log);


### PR DESCRIPTION
Jira: CT-1805
Connection: https://github.com/keboola/connection/pull/5313
Tests:  https://github.com/keboola/storage-api-php-client/pull/1409
BQ driver : https://github.com/keboola/php-storage-driver-bigquery/pull/149


---

you cannot add required column. And required means nullable=false. So we have to enable nullable=true only. Right :)