### PR TITLE
Update to PHP 8.3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.1-cli-bullseye
+ARG PHP_VERSION=8.3.19
+
+FROM php:${PHP_VERSION}-cli-bullseye
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "google/protobuf": "^3.21",
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   production: &prod
     build:

--- a/etc/docker/xdebug/Dockerfile
+++ b/etc/docker/xdebug/Dockerfile
@@ -1,4 +1,4 @@
 FROM production
 
-RUN pecl install xdebug-3.1.6 \
+RUN pecl install xdebug \
   && docker-php-ext-enable xdebug


### PR DESCRIPTION
Jira: −
Connection PR: −
SAPI PR: −

---

- Update PHP. Version in ARG like in other packages.
- Remove "version" from docker-compose.yml because of "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion" message.
- Remove Xdebug's version to get always the latest suitable version.