### PR TITLE
Support more types for execute query handler

### DIFF
--- a/src/Handler/ExecuteQuery/ExecuteQueryHandler.php
+++ b/src/Handler/ExecuteQuery/ExecuteQueryHandler.php
@@ -6,6 +6,7 @@ namespace Keboola\StorageDriver\BigQuery\Handler\ExecuteQuery;
 
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\BigQuery\Timestamp;
+use Google\Cloud\BigQuery\ValueInterface;
 use Google\Protobuf\Internal\Message;
 use Google\Service\Iam\CreateServiceAccountKeyRequest;
 use Google\Service\Iam\Resource\ProjectsServiceAccountsKeys;
@@ -163,7 +164,7 @@ final class ExecuteQueryHandler extends BaseHandler
                     throw new LogicException('Result rows must be iterable');
                 }
                 foreach ($r as $key => $value) {
-                    if ($value instanceof Timestamp) {
+                    if ($value instanceof ValueInterface) {
                         $data[$key] = $value->__toString();
                     } else {
                         $data[$key] = $value;

--- a/tests/functional/UseCase/ExecuteQuery/ExecuteQueryTest.php
+++ b/tests/functional/UseCase/ExecuteQuery/ExecuteQueryTest.php
@@ -253,9 +253,9 @@ class ExecuteQueryTest extends BaseCase
         $this->assertEquals('2024-03-16', $row['date_col']);
         $this->assertStringContainsString('POINT(51.5074 -0.1278)', $row['geography_col']);
         $this->assertEquals('{"array":[1,2,3]}', $row['json_col']);
-        $this->assertEquals('678.90', $row['numeric_col']);
-        $this->assertEquals('18:45:00', $row['time_col']);
-        $this->assertStringStartsWith('2024-03-16', $row['timestamp_col']);
+        $this->assertEquals('678.9', $row['numeric_col']);
+        $this->assertEquals('18:45:00.000000', $row['time_col']);
+        $this->assertStringStartsWith('2024-03-16 18:45:00.000000', $row['timestamp_col']);
 
         $this->assertStringContainsString('successfully', $response->getMessage());
     }


### PR DESCRIPTION

Based on: https://keboola.atlassian.net/browse/SUPPORT-12393?focusedCommentId=166892&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-166892

---
Menim logiku a namiesto  `if ($value instanceof Timestamp) {` menim na `if ($value instanceof ValueInterface) {` co umozni parsovat response pre viac datatypov + testy