### PR TITLE
DMD-433 Delete mode from numeric stats profiling metric

### DIFF
--- a/src/Profile/Column/NumericStatisticsColumnMetric.php
+++ b/src/Profile/Column/NumericStatisticsColumnMetric.php
@@ -20,13 +20,12 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
 
     public function description(): string
     {
-        return 'Basic statistics for numeric column (average, mode, median minimum, and maximum.';
+        return 'Basic statistics for numeric column (average, median minimum, and maximum.';
     }
 
     /**
      * @return array{
      *     avg: float,
-     *     mode: float,
      *     median: float,
      *     min: float,
      *     max: float,
@@ -49,7 +48,6 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
                 )
                 SELECT
                     ROUND(AVG(%s), 6) AS stats_avg,
-                    APPROX_TOP_COUNT(%s, 1)[OFFSET(0)].value AS stats_mode,
                     (
                         SELECT m
                         FROM (
@@ -70,7 +68,6 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
             $columnQuoted,
             $columnQuoted,
             $columnQuoted,
-            $columnQuoted,
         );
 
         try {
@@ -78,7 +75,6 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
              * @var array{
              *     0: array{
              *         stats_avg: float|int|Numeric,
-             *         stats_mode: float|int|Numeric,
              *         stats_median: float|int|Numeric,
              *         stats_min: float|int|Numeric,
              *         stats_max: float|int|Numeric,
@@ -92,7 +88,6 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
 
         return [
             'avg' => $this->toFloat($results[0]['stats_avg']),
-            'mode' => $this->toFloat($results[0]['stats_mode']),
             'median' => $this->toFloat($results[0]['stats_median']),
             'min' => $this->toFloat($results[0]['stats_min']),
             'max' => $this->toFloat($results[0]['stats_max']),

--- a/tests/functional/UseCase/Table/Profile/Column/DecimalColumnMetricTest.php
+++ b/tests/functional/UseCase/Table/Profile/Column/DecimalColumnMetricTest.php
@@ -140,7 +140,6 @@ final class DecimalColumnMetricTest extends BaseCase
             self::COLUMN_DECIMAL_NOT_NULLABLE,
             [
                 'avg' => 1111111117.765732,
-                'mode' => 20.0,
                 'median' => 10.5,
                 'min' => -5.25,
                 'max' => 10000000000.0,
@@ -159,7 +158,6 @@ final class DecimalColumnMetricTest extends BaseCase
             self::COLUMN_DECIMAL_NULLABLE,
             [
                 'avg' => 1666666669.458333,
-                'mode' => 10.5,
                 'median' => 5.75,
                 'min' => -5.25,
                 'max' => 10000000000.0,

--- a/tests/functional/UseCase/Table/Profile/Column/FloatColumnMetricTest.php
+++ b/tests/functional/UseCase/Table/Profile/Column/FloatColumnMetricTest.php
@@ -140,7 +140,6 @@ final class FloatColumnMetricTest extends BaseCase
             self::COLUMN_FLOAT_NOT_NULLABLE,
             [
                 'avg' => 13830.337667,
-                'mode' => 4.56,
                 'median' => 4.56,
                 'min' => -3.21,
                 'max' => 123456.789,
@@ -159,7 +158,6 @@ final class FloatColumnMetricTest extends BaseCase
             self::COLUMN_FLOAT_NULLABLE,
             [
                 'avg' => 20577.3215,
-                'mode' => 1.23,
                 'median' => 1.23,
                 'min' => -3.21,
                 'max' => 123456.789,

--- a/tests/functional/UseCase/Table/Profile/Column/IntegerColumnMetricTest.php
+++ b/tests/functional/UseCase/Table/Profile/Column/IntegerColumnMetricTest.php
@@ -140,7 +140,6 @@ final class IntegerColumnMetricTest extends BaseCase
             self::COLUMN_INT_NOT_NULLABLE,
             [
                 'avg' => 90919.272727,
-                'mode' => 5.0,
                 'median' => 3.0,
                 'min' => -10.0,
                 'max' => 999999.0,
@@ -159,7 +158,6 @@ final class IntegerColumnMetricTest extends BaseCase
             self::COLUMN_INT_NULLABLE,
             [
                 'avg' => 13.375000,
-                'mode' => 5.0,
                 'median' => 3.0,
                 'min' => -10.0,
                 'max' => 100.0,

--- a/tests/functional/UseCase/Table/ProfileTableTest.php
+++ b/tests/functional/UseCase/Table/ProfileTableTest.php
@@ -75,12 +75,12 @@ final class ProfileTableTest extends BaseCase
 
         /** @var array<string, string> $expectedColumnProfiles */
         $expectedColumnProfiles = [
-            'id' => '{"distinctCount":8,"duplicateCount":0,"nullCount":0,"numericStatistics":{"avg":4.5,"mode":8,"median":4.5,"min":1,"max":8}}', // phpcs:ignore
+            'id' => '{"distinctCount":8,"duplicateCount":0,"nullCount":0,"numericStatistics":{"avg":4.5,"median":4.5,"min":1,"max":8}}', // phpcs:ignore
             'col_string' => '{"distinctCount":7,"duplicateCount":1,"nullCount":0,"length":{"avg":14.5,"min":9,"max":20}}', // phpcs:ignore
             'col_bool' => '{"distinctCount":2,"duplicateCount":5,"nullCount":1}',
-            'col_int' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":75.714286,"mode":120,"median":60,"min":0,"max":200}}', // phpcs:ignore
-            'col_decimal' => '{"distinctCount":6,"duplicateCount":1,"nullCount":1,"numericStatistics":{"avg":108.838571,"mode":29.99,"median":29.99,"min":15.5,"max":499}}', // phpcs:ignore
-            'col_float' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":4.114286,"mode":4.5,"median":4.5,"min":2.4,"max":4.9}}', // phpcs:ignore
+            'col_int' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":75.714286,"median":60,"min":0,"max":200}}', // phpcs:ignore
+            'col_decimal' => '{"distinctCount":6,"duplicateCount":1,"nullCount":1,"numericStatistics":{"avg":108.838571,"median":29.99,"min":15.5,"max":499}}', // phpcs:ignore
+            'col_float' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":4.114286,"median":4.5,"min":2.4,"max":4.9}}', // phpcs:ignore
             'col_date' => '{"distinctCount":6,"duplicateCount":1,"nullCount":1}',
         ];
 


### PR DESCRIPTION
**Jira**: DMD-433
**KBC**: [keboola/connection#6242](https://github.com/keboola/connection/pull/6242)
**SAPI**: [keboola/storage-api-php-client#1577](https://github.com/keboola/storage-api-php-client/pull/1577)
**Snowflake driver**: [keboola/storage-backend#246](https://github.com/keboola/storage-backend/pull/246)

---

**Release Notes**
- Remove mode value from table profiling numeric statistics.

**Impact analysis**
- None

**Change type**
- Fix

**Justification**
- Mode doesn't return all values for multimodal sets. Now we have no time for stable solution. So we will remove mode from numeric statistics metric.
