### PR TITLE
DMD-452 - fix nullability for PKs

### DIFF
--- a/src/Handler/Workspace/Load/StageTableDefinitionFactory.php
+++ b/src/Handler/Workspace/Load/StageTableDefinitionFactory.php
@@ -21,7 +21,6 @@ final class StageTableDefinitionFactory
         array $columnsMapping,
     ): BigqueryTableDefinition {
         $newDefinitions = [];
-        $primaries = $destination->getPrimaryKeysNames();
         foreach ($columnsMapping as $columnMapping) {
             /** @var BigqueryColumn $definition */
             foreach ($destination->getColumnsDefinitions() as $definition) {
@@ -33,7 +32,7 @@ final class StageTableDefinitionFactory
                             $definition->getColumnDefinition()->getType(),
                             [
                                 'length' => $definition->getColumnDefinition()->getLength(),
-                                'nullable' => !in_array($columnMapping->getDestinationColumnName(), $primaries),
+                                'nullable' => $definition->getColumnDefinition()->isNullable(),
                                 'default' => $definition->getColumnDefinition()->getDefault(),
                             ],
                         ),

--- a/tests/functional/UseCase/Workspace/Load/LoadIncrementalFromTableTest.php
+++ b/tests/functional/UseCase/Workspace/Load/LoadIncrementalFromTableTest.php
@@ -1072,7 +1072,7 @@ SQL,
                 $destinationTableName,
                 false,
                 new ColumnCollection([
-                    new BigqueryColumn('id', new Bigquery(Bigquery::TYPE_STRING, ['nullable' => true])),
+                    new BigqueryColumn('id', new Bigquery(Bigquery::TYPE_STRING, ['nullable' => false])),
                     new BigqueryColumn('name', new Bigquery(Bigquery::TYPE_STRING, [])),
                     BigqueryColumn::createTimestampColumn('_timestamp'),
                 ]),


### PR DESCRIPTION
What the fix does:
  - The staging table now preserves the source table's actual nullability setting from the destination definition
  - Previously, primary key columns were forced to NOT NULL regardless of their actual nullability in Storage
  - Now columns retain their nullable status from the source table, allowing NULL values to be inserted even for primary key columns when the source permits it

Linear: https://linear.app/keboola/issue/DMD-452/bq-copy-im
Connection PR: https://github.com/keboola/connection/pull/6455

---
