### PR TITLE
DMD-988 reset PKs when using full importer

### DIFF
--- a/src/Handler/Workspace/Load/LoadTableToWorkspaceHandler.php
+++ b/src/Handler/Workspace/Load/LoadTableToWorkspaceHandler.php
@@ -337,7 +337,7 @@ class LoadTableToWorkspaceHandler extends BaseHandler
                      * 2. src table is string and casting required (19,20)
                      */
 
-                    /* when FULL loading from workspace to workspace and PKs are defined, there is no point of doing
+                    /* when FULL loading from Storage to workspace and PKs are defined, there is no point of doing
                      * deduplication because PKs are inherited from Storage (so the data are deduped already).
                      * If PKs would be passed to importer, it woulc
                      *  1. do dedup operations for no reason

--- a/src/Handler/Workspace/Load/LoadTableToWorkspaceHandler.php
+++ b/src/Handler/Workspace/Load/LoadTableToWorkspaceHandler.php
@@ -337,11 +337,28 @@ class LoadTableToWorkspaceHandler extends BaseHandler
                      * 2. src table is string and casting required (19,20)
                      */
 
+                    /* when FULL loading from workspace to workspace and PKs are defined, there is no point of doing
+                     * deduplication because PKs are inherited from Storage (so the data are deduped already).
+                     * If PKs would be passed to importer, it woulc
+                     *  1. do dedup operations for no reason
+                     *  2. it would create dedup table in source dataset, which could be read-only (external dataset)
+                     */
+                    $destinationDefinitionToUse = $destinationDefinition;
+                    if (!empty($destinationDefinition->getPrimaryKeysNames())) {
+                        $destinationDefinitionToUse = new BigqueryTableDefinition(
+                            $destinationDefinition->getSchemaName(),
+                            $destinationDefinition->getTableName(),
+                            $destinationDefinition->isTemporary(),
+                            $destinationDefinition->getColumnsDefinitions(),
+                            [],
+                        );
+                    }
+
                     $importer = new FullImporter($bqClient);
                     try {
                         $importResult = $importer->importToTable(
                             $sourceTableDefinition,
-                            $destinationDefinition,
+                            $destinationDefinitionToUse,
                             $importOptions,
                             new ImportState($destinationDefinition->getTableName()),
                         );


### PR DESCRIPTION
Jira: DMD-988
Connection PR:  https://github.com/keboola/connection/pull/6549
SAPI PR: XXX

---

set PK to `[]` when using FullImporter. There is no point for deduplicate deduplicated data 