### PR TITLE
fix: use all-STRING staging table for STRING_TABLE import strategy

### DIFF
--- a/src/Handler/Table/Import/ImportTableFromFileHandler.php
+++ b/src/Handler/Table/Import/ImportTableFromFileHandler.php
@@ -23,6 +23,7 @@ use Keboola\StorageDriver\Command\Table\ImportExportShared\FileFormat;
 use Keboola\StorageDriver\Command\Table\ImportExportShared\FilePath;
 use Keboola\StorageDriver\Command\Table\ImportExportShared\FileProvider;
 use Keboola\StorageDriver\Command\Table\ImportExportShared\ImportOptions;
+use Keboola\StorageDriver\Command\Table\ImportExportShared\ImportOptions\ImportStrategy;
 use Keboola\StorageDriver\Command\Table\TableImportFromFileCommand;
 use Keboola\StorageDriver\Command\Table\TableImportResponse;
 use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
@@ -124,10 +125,17 @@ final class ImportTableFromFileHandler extends BaseHandler
                 );
             }
             // prepare staging table definition
-            $stagingTable = StageTableDefinitionFactory::createStagingTableDefinition(
-                $destinationDefinition,
-                $source->getColumnsNames(),
-            );
+            if ($importOptions->getImportStrategy() === ImportStrategy::STRING_TABLE) {
+                $stagingTable = StageTableDefinitionFactory::createStagingTableDefinitionWithText(
+                    $destinationDefinition,
+                    $source->getColumnsNames(),
+                );
+            } else {
+                $stagingTable = StageTableDefinitionFactory::createStagingTableDefinition(
+                    $destinationDefinition,
+                    $source->getColumnsNames(),
+                );
+            }
             // create staging table
             $qb = new BigqueryTableQueryBuilder();
             $query = $bqClient->query(

--- a/src/Handler/Table/Import/ImportTableFromFileHandler.php
+++ b/src/Handler/Table/Import/ImportTableFromFileHandler.php
@@ -124,7 +124,13 @@ final class ImportTableFromFileHandler extends BaseHandler
                     $dedupColumns, // add dedup columns separately as BQ has no primary keys
                 );
             }
-            // prepare staging table definition
+            // Prepare staging table definition.
+            // STRING_TABLE: all columns are STRING — used for cross-backend CSV loads where
+            // source format may not match BigQuery's typed column expectations. Type casting
+            // is deferred to the SQL layer (FullImporter/IncrementalImporter via SqlBuilder).
+            // USER_DEFINED_TABLE: columns match destination types — used for same-backend loads
+            // where CSV format is guaranteed to be compatible with BigQuery's CSV parser.
+            // See LoadTableWithDriver::importTableDataFromStaging() for the strategy decision.
             if ($importOptions->getImportStrategy() === ImportStrategy::STRING_TABLE) {
                 $stagingTable = StageTableDefinitionFactory::createStagingTableDefinitionWithText(
                     $destinationDefinition,

--- a/src/Handler/Table/Import/StageTableDefinitionFactory.php
+++ b/src/Handler/Table/Import/StageTableDefinitionFactory.php
@@ -98,6 +98,27 @@ final class StageTableDefinitionFactory
         );
     }
 
+    /**
+     * @param array<string> $sourceColumnsNames
+     */
+    public static function createStagingTableDefinitionWithText(
+        BigqueryTableDefinition $destination,
+        array $sourceColumnsNames,
+    ): BigqueryTableDefinition {
+        $newDefinitions = [];
+        foreach ($sourceColumnsNames as $columnName) {
+            $newDefinitions[] = self::createVarcharColumn($columnName);
+        }
+
+        return new BigqueryTableDefinition(
+            $destination->getSchemaName(),
+            BackendHelper::generateStagingTableName(),
+            true,
+            new ColumnCollection($newDefinitions),
+            [],
+        );
+    }
+
     private static function createVarcharColumn(string $columnName): BigqueryColumn
     {
         return new BigqueryColumn(

--- a/src/Handler/Table/Import/StageTableDefinitionFactory.php
+++ b/src/Handler/Table/Import/StageTableDefinitionFactory.php
@@ -6,6 +6,7 @@ namespace Keboola\StorageDriver\BigQuery\Handler\Table\Import;
 
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\Db\ImportExport\Backend\Helper\BackendHelper;
+use Keboola\Db\ImportExport\Backend\ToStageImporterInterface;
 use Keboola\StorageDriver\Command\Table\TableImportFromTableCommand\SourceTableMapping\ColumnMapping;
 use Keboola\TableBackendUtils\Column\Bigquery\BigqueryColumn;
 use Keboola\TableBackendUtils\Column\ColumnCollection;
@@ -107,6 +108,26 @@ final class StageTableDefinitionFactory
     ): BigqueryTableDefinition {
         $newDefinitions = [];
         foreach ($sourceColumnsNames as $columnName) {
+            // _timestamp must keep TIMESTAMP type from destination to avoid type mismatch during MERGE
+            if ($columnName === ToStageImporterInterface::TIMESTAMP_COLUMN_NAME) {
+                /** @var BigqueryColumn $definition */
+                foreach ($destination->getColumnsDefinitions() as $definition) {
+                    if ($definition->getColumnName() === $columnName) {
+                        $newDefinitions[] = new BigqueryColumn(
+                            $columnName,
+                            new Bigquery(
+                                $definition->getColumnDefinition()->getType(),
+                                [
+                                    'length' => $definition->getColumnDefinition()->getLength(),
+                                    'nullable' => true,
+                                    'default' => $definition->getColumnDefinition()->getDefault(),
+                                ],
+                            ),
+                        );
+                        continue 2;
+                    }
+                }
+            }
             $newDefinitions[] = self::createVarcharColumn($columnName);
         }
 

--- a/tests/unit/IAMServiceWrapperTest.php
+++ b/tests/unit/IAMServiceWrapperTest.php
@@ -82,9 +82,6 @@ class IAMServiceWrapperTest extends TestCase
     /**
      * @return array<string, array<string, mixed>>
      */
-    /**
-     * @return array<string, array<string, mixed>>
-     */
     private function getResourceMethods(object $resource): array
     {
         $ref = new ReflectionProperty(Resource::class, 'methods');


### PR DESCRIPTION
Add createStagingTableDefinitionWithText() method that creates staging columns as STRING type. When import strategy is STRING_TABLE, use this method instead of createStagingTableDefinition() which preserves destination column types. This fixes COALESCE type mismatch errors (e.g., INT64 vs STRING) during cross-backend workspace loads.

Linear: [DMD-849](https://linear.app/keboola/issue/DMD-849/replace-mixed-rs-snflk-suite-with-logic-to-snowflake-bq)
Connection PR: https://github.com/keboola/connection/pull/6642

---
