### PR TITLE
feat: support skipDuplicatesCheck in AddPrimaryKeyHandler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,9 @@ jobs:
       - name: Build Image
         run: docker compose build production
 
-      # TODO: revert back to `composer ci` once storage-driver-common is released
       - name: Check
         run: |
-          docker compose run --rm production composer phplint
-          docker compose run --rm production composer phpcs
-          docker compose run --rm production composer phpstan
-          docker compose run --rm production composer tests-unit
+          docker compose run --rm production composer ci
 
       - name: Prepare stubs
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,13 @@ jobs:
       - name: Build Image
         run: docker compose build production
 
+      # TODO: revert back to `composer ci` once storage-driver-common is released
       - name: Check
         run: |
-          docker compose run --rm production composer ci
+          docker compose run --rm production composer phplint
+          docker compose run --rm production composer phpcs
+          docker compose run --rm production composer phpstan
+          docker compose run --rm production composer tests-unit
 
       - name: Prepare stubs
         env:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "google/protobuf": "^3.21",
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
-        "keboola/storage-driver-common": "dev-vb/DMD-981/bq_skipDuplicatesCheck#b08f8b7127df06a199e2d88c032171189c4a5c40 as 7.15.0",
+        "keboola/storage-driver-common": "^v7.15.0",
         "google/cloud-resource-manager": "^0.6.1",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.16",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "google/protobuf": "^3.21",
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
-        "keboola/storage-driver-common": "^7.14.0",
+        "keboola/storage-driver-common": "dev-vb/DMD-981/bq_skipDuplicatesCheck#b08f8b7127df06a199e2d88c032171189c4a5c40 as 7.15.0",
         "google/cloud-resource-manager": "^0.6.1",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.16",

--- a/src/Handler/Table/Alter/AddPrimaryKeyHandler.php
+++ b/src/Handler/Table/Alter/AddPrimaryKeyHandler.php
@@ -59,33 +59,36 @@ class AddPrimaryKeyHandler extends BaseHandler
         /** @var string $databaseName */
         $databaseName = $command->getPath()[0];
 
-        // detect duplicities
         $desiredPks = ProtobufHelper::repeatedStringToArray($command->getPrimaryKeysNames());
-        $formattedColumns = implode(
-            ',',
-            array_map(
-                fn($item) => BigqueryQuote::quoteSingleIdentifier($item),
-                $desiredPks,
-            ),
-        );
-        $sqlCommand = sprintf(
+
+        // detect duplicities
+        if (!$command->getSkipDuplicatesCheck()) {
+            $formattedColumns = implode(
+                ',',
+                array_map(
+                    fn($item) => BigqueryQuote::quoteSingleIdentifier($item),
+                    $desiredPks,
+                ),
+            );
+            $sqlCommand = sprintf(
 /** @lang BigQuery */<<<SQL
 SELECT MAX(`_row_number_`) AS `max` FROM
 (
     SELECT ROW_NUMBER() OVER (PARTITION BY %s) AS `_row_number_` FROM %s.%s
 ) `data`
 SQL,
-            $formattedColumns,
-            BigqueryQuote::quoteSingleIdentifier($databaseName),
-            BigqueryQuote::quoteSingleIdentifier($command->getTableName()),
-        );
+                $formattedColumns,
+                BigqueryQuote::quoteSingleIdentifier($databaseName),
+                BigqueryQuote::quoteSingleIdentifier($command->getTableName()),
+            );
 
-        $result = iterator_to_array($bqClient->runQuery($bqClient->query($sqlCommand)));
-        assert(count($result) === 1, 'Query to check duplicates is expected to return exactly one row');
-        assert(is_array($result[0]), 'Expected array result');
-        assert(array_key_exists('max', $result[0]), 'Expected "max" key in result');
-        if ($result[0]['max'] > 1) {
-            throw CannotAddPrimaryKeyException::createForDuplicates();
+            $result = iterator_to_array($bqClient->runQuery($bqClient->query($sqlCommand)));
+            assert(count($result) === 1, 'Query to check duplicates is expected to return exactly one row');
+            assert(is_array($result[0]), 'Expected array result');
+            assert(array_key_exists('max', $result[0]), 'Expected "max" key in result');
+            if ($result[0]['max'] > 1) {
+                throw CannotAddPrimaryKeyException::createForDuplicates();
+            }
         }
 
         // check if table has PK set

--- a/tests/functional/UseCase/Table/PrimaryKeyTest.php
+++ b/tests/functional/UseCase/Table/PrimaryKeyTest.php
@@ -173,6 +173,71 @@ class PrimaryKeyTest extends BaseCase
         );
     }
 
+    public function testDuplicatesSkipCheck(): void
+    {
+        $tableName = md5($this->getName()) . '_Test_table';
+        $bucketDatabaseName = $this->bucketResponse->getCreateBucketObjectName();
+
+        // CREATE TABLE
+        $tableStructure = [
+            'columns' => [
+                'col1' => [
+                    'type' => Bigquery::TYPE_INTEGER,
+                    'length' => '',
+                    'nullable' => false,
+                ],
+                'col2' => [
+                    'type' => Bigquery::TYPE_INTEGER,
+                    'length' => '',
+                    'nullable' => false,
+                ],
+                'col3' => [
+                    'type' => Bigquery::TYPE_INTEGER,
+                    'length' => '',
+                    'nullable' => false,
+                ],
+            ],
+            'primaryKeysNames' => [],
+        ];
+        $this->createTable($this->projectCredentials, $bucketDatabaseName, $tableName, $tableStructure);
+
+        $this->fillTableWithData(
+            $this->projectCredentials,
+            $bucketDatabaseName,
+            $tableName,
+            [['columns' => '`col1`,`col2`,`col3`', 'rows' => ['1,5,6', '1,5,6']]],
+        );
+
+        $path = new RepeatedField(GPBType::STRING);
+        $path[] = $bucketDatabaseName;
+
+        $pkNames = new RepeatedField(GPBType::STRING);
+        $pkNames[] = 'col2';
+        $pkNames[] = 'col3';
+
+        // add PK with skipDuplicatesCheck — should succeed despite duplicates
+        $addPKCommand = (new AddPrimaryKeyCommand())
+            ->setPath($path)
+            ->setTableName($tableName)
+            ->setPrimaryKeysNames($pkNames)
+            ->setSkipDuplicatesCheck(true);
+        $addPKHandler = new AddPrimaryKeyHandler($this->clientManager);
+        $addPKHandler->setInternalLogger($this->log);
+        $addPKHandler(
+            $this->projectCredentials,
+            $addPKCommand,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+
+        $bqClient = $this->clientManager->getBigQueryClient(
+            $this->testRunId,
+            $this->projectCredentials,
+        );
+        $ref = new BigqueryTableReflection($bqClient, $bucketDatabaseName, $tableName);
+        $this->assertEquals(['col2', 'col3'], $ref->getPrimaryKeysNames());
+    }
+
     public function testPKExists(): void
     {
         $tableName = md5($this->getName()) . '_Test_table';


### PR DESCRIPTION
Wrap the duplicate detection query in a conditional so it is skipped when AddPrimaryKeyCommand.skipDuplicatesCheck is true. Add functional test testDuplicatesSkipCheck to verify PK creation succeeds with duplicates when the flag is set.

Linear: [DMD-981](https://linear.app/keboola/issue/DMD-981/implement-skipduplicatescheck-for-bigquery-driver)
Connection PR: https://github.com/keboola/connection/pull/6678

---
