### PR TITLE
DMD-745 Add DirectGrant workspace functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "google/protobuf": "^3.21",
         "keboola/php-file-storage-utils": "^0.2.5",
         "ext-json": "*",
-        "keboola/storage-driver-common": ">=7.12.0",
+        "keboola/storage-driver-common": "^7.14.0",
         "google/cloud-resource-manager": "^0.6.1",
         "google/cloud-service-usage": "^0.2.7",
         "google/apiclient": "^2.16",

--- a/src/Handler/Workspace/Create/CreateWorkspaceHandler.php
+++ b/src/Handler/Workspace/Create/CreateWorkspaceHandler.php
@@ -192,13 +192,17 @@ final class CreateWorkspaceHandler extends BaseHandler
         // grant table-level IAM for direct grant tables
         foreach ($command->getDirectGrantTables() as $directGrantTable) {
             /** @var \Keboola\StorageDriver\Command\Workspace\DirectGrantTable $directGrantTable */
-            $table = $bqClient->dataset(ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0])
+            $path = ProtobufHelper::repeatedStringToArray($directGrantTable->getPath());
+            assert(count($path) > 0, 'DirectGrantTable path must not be empty');
+            $datasetName = $path[0];
+
+            $table = $bqClient->dataset($datasetName)
                 ->table($directGrantTable->getTableName());
 
-            $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($directGrantTable) {
+            $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($datasetName, $directGrantTable) {
                 $this->internalLogger->debug(sprintf(
                     'Try set table IAM policy for %s.%s Err: %s',
-                    ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                    $datasetName,
                     $directGrantTable->getTableName(),
                     $e->getMessage(),
                 ));
@@ -211,19 +215,36 @@ final class CreateWorkspaceHandler extends BaseHandler
             );
             $tableIamProxy = new RetryProxy($retryPolicy, $backOffPolicy);
 
-            $tableIamProxy->call(function () use ($table, $wsServiceAcc, $directGrantTable): void {
+            $tableIamProxy->call(function () use ($table, $wsServiceAcc, $datasetName, $directGrantTable): void {
                 $policy = $table->iam()->policy();
-                $policy['bindings'][] = [
-                    'role' => IAmPermissions::ROLES_BIGQUERY_DATA_EDITOR,
-                    'members' => ['serviceAccount:' . $wsServiceAcc->getEmail()],
-                ];
+                $role = IAmPermissions::ROLES_BIGQUERY_DATA_EDITOR;
+                $member = 'serviceAccount:' . $wsServiceAcc->getEmail();
+                $bindings = $policy['bindings'] ?? [];
+                $found = false;
+                foreach ($bindings as &$binding) {
+                    if (($binding['role'] ?? '') === $role) {
+                        if (!in_array($member, $binding['members'] ?? [], true)) {
+                            $binding['members'][] = $member;
+                        }
+                        $found = true;
+                        break;
+                    }
+                }
+                unset($binding);
+                if (!$found) {
+                    $bindings[] = [
+                        'role' => $role,
+                        'members' => [$member],
+                    ];
+                }
+                $policy['bindings'] = $bindings;
                 $table->iam()->setPolicy($policy);
                 $this->internalLogger->log(
                     LogLevel::DEBUG,
                     sprintf(
                         'Set table IAM policy (dataEditor) for %s on %s.%s',
                         $wsServiceAcc->getEmail(),
-                        ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                        $datasetName,
                         $directGrantTable->getTableName(),
                     ),
                 );

--- a/src/Handler/Workspace/Create/CreateWorkspaceHandler.php
+++ b/src/Handler/Workspace/Create/CreateWorkspaceHandler.php
@@ -20,6 +20,7 @@ use Keboola\StorageDriver\Command\Workspace\CreateWorkspaceCommand;
 use Keboola\StorageDriver\Command\Workspace\CreateWorkspaceResponse;
 use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
 use Keboola\StorageDriver\Shared\Driver\BaseHandler;
+use Keboola\StorageDriver\Shared\Utils\ProtobufHelper;
 use Psr\Log\LogLevel;
 use Retry\BackOff\ExponentialRandomBackOffPolicy;
 use Retry\Policy\CallableRetryPolicy;
@@ -187,6 +188,47 @@ final class CreateWorkspaceHandler extends BaseHandler
                 $this->internalLogger,
             );
         });
+
+        // grant table-level IAM for direct grant tables
+        foreach ($command->getDirectGrantTables() as $directGrantTable) {
+            /** @var \Keboola\StorageDriver\Command\Workspace\DirectGrantTable $directGrantTable */
+            $table = $bqClient->dataset(ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0])
+                ->table($directGrantTable->getTableName());
+
+            $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($directGrantTable) {
+                $this->internalLogger->debug(sprintf(
+                    'Try set table IAM policy for %s.%s Err: %s',
+                    ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                    $directGrantTable->getTableName(),
+                    $e->getMessage(),
+                ));
+                return true;
+            }, 5);
+            $backOffPolicy = new ExponentialRandomBackOffPolicy(
+                5_000, // 5s
+                1.8,
+                60_000, // 1m
+            );
+            $tableIamProxy = new RetryProxy($retryPolicy, $backOffPolicy);
+
+            $tableIamProxy->call(function () use ($table, $wsServiceAcc, $directGrantTable): void {
+                $policy = $table->iam()->policy();
+                $policy['bindings'][] = [
+                    'role' => IAmPermissions::ROLES_BIGQUERY_DATA_EDITOR,
+                    'members' => ['serviceAccount:' . $wsServiceAcc->getEmail()],
+                ];
+                $table->iam()->setPolicy($policy);
+                $this->internalLogger->log(
+                    LogLevel::DEBUG,
+                    sprintf(
+                        'Set table IAM policy (dataEditor) for %s on %s.%s',
+                        $wsServiceAcc->getEmail(),
+                        ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                        $directGrantTable->getTableName(),
+                    ),
+                );
+            });
+        }
 
         // generate credentials
         [$privateKey, $publicPart,] = $iamService->createKeyFileCredentials($wsServiceAcc);

--- a/src/Handler/Workspace/Drop/DropWorkspaceHandler.php
+++ b/src/Handler/Workspace/Drop/DropWorkspaceHandler.php
@@ -129,17 +129,21 @@ final class DropWorkspaceHandler extends BaseHandler
 
         foreach ($command->getDirectGrantTables() as $directGrantTable) {
             /** @var DirectGrantTable $directGrantTable */
-            $table = $bqClient->dataset(ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0])
+            $path = ProtobufHelper::repeatedStringToArray($directGrantTable->getPath());
+            assert(count($path) > 0, 'DirectGrantTable path must not be empty');
+            $datasetName = $path[0];
+
+            $table = $bqClient->dataset($datasetName)
                 ->table($directGrantTable->getTableName());
 
-            $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($directGrantTable) {
+            $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($datasetName, $directGrantTable) {
                 // Do not retry 404 - table may have been deleted before workspace
                 if ($e->getCode() === 404) {
                     return false;
                 }
                 $this->internalLogger->debug(sprintf(
                     'Try revoke table IAM policy for %s.%s Err: %s',
-                    ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                    $datasetName,
                     $directGrantTable->getTableName(),
                     $e->getMessage(),
                 ));
@@ -153,7 +157,7 @@ final class DropWorkspaceHandler extends BaseHandler
             $proxy = new RetryProxy($retryPolicy, $backOffPolicy);
 
             try {
-                $proxy->call(function () use ($table, $saIdentifier, $directGrantTable): void {
+                $proxy->call(function () use ($table, $saIdentifier, $datasetName, $directGrantTable): void {
                     $policy = $table->iam()->policy();
                     $newBindings = [];
                     foreach ($policy['bindings'] ?? [] as $binding) {
@@ -171,7 +175,7 @@ final class DropWorkspaceHandler extends BaseHandler
                     $this->internalLogger->debug(sprintf(
                         'Revoked table IAM policy (dataEditor) for %s on %s.%s',
                         $saIdentifier,
-                        ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                        $datasetName,
                         $directGrantTable->getTableName(),
                     ));
                 });
@@ -180,7 +184,7 @@ final class DropWorkspaceHandler extends BaseHandler
                     // Table was deleted before workspace - skip silently
                     $this->internalLogger->debug(sprintf(
                         'Table %s.%s not found, skipping IAM revoke',
-                        ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                        $datasetName,
                         $directGrantTable->getTableName(),
                     ));
                     continue;

--- a/src/Handler/Workspace/Drop/DropWorkspaceHandler.php
+++ b/src/Handler/Workspace/Drop/DropWorkspaceHandler.php
@@ -13,9 +13,11 @@ use Google\Service\CloudResourceManager\Policy;
 use Google\Service\CloudResourceManager\SetIamPolicyRequest;
 use Keboola\StorageDriver\BigQuery\CredentialsHelper;
 use Keboola\StorageDriver\BigQuery\GCPClientManager;
+use Keboola\StorageDriver\Command\Workspace\DirectGrantTable;
 use Keboola\StorageDriver\Command\Workspace\DropWorkspaceCommand;
 use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
 use Keboola\StorageDriver\Shared\Driver\BaseHandler;
+use Keboola\StorageDriver\Shared\Utils\ProtobufHelper;
 use Retry\BackOff\ExponentialRandomBackOffPolicy;
 use Retry\Policy\CallableRetryPolicy;
 use Retry\RetryProxy;
@@ -66,6 +68,7 @@ final class DropWorkspaceHandler extends BaseHandler
         $keyData = json_decode($command->getWorkspaceUserName(), true, 512, JSON_THROW_ON_ERROR);
 
         $this->deleteDataset($bqClient, $command);
+        $this->revokeDirectGrantTableIam($bqClient, $command, $keyData['client_email']);
         $this->dropIamPolicies($credentials, $keyData['client_email']);
         $this->cancelRunningJobs($bqClient, $keyData['client_email']);
         $this->deleteServiceAccount($credentials, $keyData['project_id'], $keyData['client_email']);
@@ -113,6 +116,76 @@ final class DropWorkspaceHandler extends BaseHandler
                         $e->getMessage(),
                     ));
                 }
+            }
+        }
+    }
+
+    private function revokeDirectGrantTableIam(
+        BigQueryClient $bqClient,
+        DropWorkspaceCommand $command,
+        string $serviceAccountEmail,
+    ): void {
+        $saIdentifier = 'serviceAccount:' . $serviceAccountEmail;
+
+        foreach ($command->getDirectGrantTables() as $directGrantTable) {
+            /** @var DirectGrantTable $directGrantTable */
+            $table = $bqClient->dataset(ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0])
+                ->table($directGrantTable->getTableName());
+
+            $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($directGrantTable) {
+                // Do not retry 404 - table may have been deleted before workspace
+                if ($e->getCode() === 404) {
+                    return false;
+                }
+                $this->internalLogger->debug(sprintf(
+                    'Try revoke table IAM policy for %s.%s Err: %s',
+                    ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                    $directGrantTable->getTableName(),
+                    $e->getMessage(),
+                ));
+                return true;
+            }, 5);
+            $backOffPolicy = new ExponentialRandomBackOffPolicy(
+                5_000, // 5s
+                1.8,
+                60_000, // 1m
+            );
+            $proxy = new RetryProxy($retryPolicy, $backOffPolicy);
+
+            try {
+                $proxy->call(function () use ($table, $saIdentifier, $directGrantTable): void {
+                    $policy = $table->iam()->policy();
+                    $newBindings = [];
+                    foreach ($policy['bindings'] ?? [] as $binding) {
+                        $filteredMembers = array_values(array_filter(
+                            $binding['members'] ?? [],
+                            fn(string $member) => $member !== $saIdentifier,
+                        ));
+                        if ($filteredMembers !== []) {
+                            $binding['members'] = $filteredMembers;
+                            $newBindings[] = $binding;
+                        }
+                    }
+                    $policy['bindings'] = $newBindings;
+                    $table->iam()->setPolicy($policy);
+                    $this->internalLogger->debug(sprintf(
+                        'Revoked table IAM policy (dataEditor) for %s on %s.%s',
+                        $saIdentifier,
+                        ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                        $directGrantTable->getTableName(),
+                    ));
+                });
+            } catch (Throwable $e) {
+                if ($e->getCode() === 404) {
+                    // Table was deleted before workspace - skip silently
+                    $this->internalLogger->debug(sprintf(
+                        'Table %s.%s not found, skipping IAM revoke',
+                        ProtobufHelper::repeatedStringToArray($directGrantTable->getPath())[0],
+                        $directGrantTable->getTableName(),
+                    ));
+                    continue;
+                }
+                throw $e;
             }
         }
     }

--- a/src/IAmPermissions.php
+++ b/src/IAmPermissions.php
@@ -6,6 +6,7 @@ namespace Keboola\StorageDriver\BigQuery;
 
 final class IAmPermissions
 {
+    public const ROLES_BIGQUERY_DATA_EDITOR = 'roles/bigquery.dataEditor';
     public const ROLES_BIGQUERY_DATA_OWNER = 'roles/bigquery.dataOwner';
     public const ROLES_BIGQUERY_DATA_VIEWER = 'roles/bigquery.dataViewer';
     public const ROLES_BIGQUERY_JOB_USER = 'roles/bigquery.jobUser';

--- a/tests/functional/UseCase/Workspace/DirectGrantWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/DirectGrantWorkspaceTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageDriver\FunctionalTests\UseCase\Workspace;
+
+use Google\Cloud\Core\Exception\ServiceException;
+use Google\Protobuf\Any;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\StorageDriver\BigQuery\CredentialsHelper;
+use Keboola\StorageDriver\BigQuery\Handler\Workspace\Create\CreateWorkspaceHandler;
+use Keboola\StorageDriver\BigQuery\Handler\Workspace\Drop\DropWorkspaceHandler;
+use Keboola\StorageDriver\BigQuery\NameGenerator;
+use Keboola\StorageDriver\Command\Common\RuntimeOptions;
+use Keboola\StorageDriver\Command\Project\CreateProjectResponse;
+use Keboola\StorageDriver\Command\Workspace\CreateWorkspaceCommand;
+use Keboola\StorageDriver\Command\Workspace\CreateWorkspaceResponse;
+use Keboola\StorageDriver\Command\Workspace\DirectGrantTable;
+use Keboola\StorageDriver\Command\Workspace\DropWorkspaceCommand;
+use Keboola\StorageDriver\Credentials\GenericBackendCredentials;
+use Keboola\StorageDriver\FunctionalTests\BaseCase;
+use Keboola\StorageDriver\Shared\Utils\ProtobufHelper;
+use Keboola\TableBackendUtils\Escaping\Bigquery\BigqueryQuote;
+use Throwable;
+
+/**
+ * @group sync
+ */
+class DirectGrantWorkspaceTest extends BaseCase
+{
+    protected GenericBackendCredentials $projectCredentials;
+
+    protected CreateProjectResponse $projectResponse;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->projectCredentials = $this->projects[0][0];
+        $this->projectResponse = $this->projects[0][1];
+    }
+
+    public function testCreateWorkspaceWithDirectGrantTables(): void
+    {
+        // 1. Create a bucket with a table that we will grant access to
+        $bucketResponse = $this->createTestBucket($this->projectCredentials);
+        $bucketDatasetName = $bucketResponse->getCreateBucketObjectName();
+
+        $grantedTableName = 'granted_table';
+        $grantedTable2Name = 'granted_table_2';
+        $nonGrantedTableName = 'non_granted_table';
+
+        $tableStructure = [
+            'columns' => [
+                'id' => [
+                    'type' => Bigquery::TYPE_INT64,
+                    'nullable' => false,
+                    'length' => '',
+                ],
+                'name' => [
+                    'type' => Bigquery::TYPE_STRING,
+                    'nullable' => true,
+                    'length' => '',
+                ],
+            ],
+            'primaryKeysNames' => [],
+        ];
+
+        // Create all tables in bucket using project credentials
+        $this->createTable($this->projectCredentials, $bucketDatasetName, $grantedTableName, $tableStructure);
+        $this->createTable($this->projectCredentials, $bucketDatasetName, $grantedTable2Name, $tableStructure);
+        $this->createTable($this->projectCredentials, $bucketDatasetName, $nonGrantedTableName, $tableStructure);
+
+        // Insert some initial data into all tables
+        $bqProjectClient = $this->clientManager->getBigQueryClient($this->testRunId, $this->projectCredentials);
+        $bqProjectClient->runQuery($bqProjectClient->query(sprintf(
+            'INSERT INTO %s.%s (`id`, `name`) VALUES (1, \'initial\')',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+        $bqProjectClient->runQuery($bqProjectClient->query(sprintf(
+            'INSERT INTO %s.%s (`id`, `name`) VALUES (1, \'initial\')',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTable2Name),
+        )));
+        $bqProjectClient->runQuery($bqProjectClient->query(sprintf(
+            'INSERT INTO %s.%s (`id`, `name`) VALUES (1, \'initial\')',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($nonGrantedTableName),
+        )));
+
+        // 2. Create workspace WITH direct grant on granted_table
+        $workspaceId = 'WS' . substr($this->getTestHash(), -7) . self::getRand();
+        // Cleanup any pre-existing workspace dataset
+        $nameGenerator = new NameGenerator($this->getStackPrefix());
+        $wsDatasetName = $nameGenerator->createWorkspaceObjectNameForWorkspaceId($workspaceId);
+        $bqCleanupClient = $this->clientManager->getBigQueryClient($this->testRunId, $this->projectCredentials);
+        try {
+            $bqCleanupClient->dataset($wsDatasetName)->delete(['deleteContents' => true]);
+        } catch (Throwable) {
+            // ignore if not exists
+        }
+
+        $handler = new CreateWorkspaceHandler($this->clientManager);
+        $handler->setInternalLogger($this->log);
+        $command = (new CreateWorkspaceCommand())
+            ->setStackPrefix($this->getStackPrefix())
+            ->setWorkspaceId($workspaceId)
+            ->setProjectReadOnlyRoleName($this->projectResponse->getProjectReadOnlyRoleName());
+
+        // Add direct grant tables
+        $command->getDirectGrantTables()[] = (new DirectGrantTable())
+            ->setPath(ProtobufHelper::arrayToRepeatedString([$bucketDatasetName]))
+            ->setTableName($grantedTableName);
+        $command->getDirectGrantTables()[] = (new DirectGrantTable())
+            ->setPath(ProtobufHelper::arrayToRepeatedString([$bucketDatasetName]))
+            ->setTableName($grantedTable2Name);
+
+        $meta = new Any();
+        $meta->pack(new CreateWorkspaceCommand\CreateWorkspaceBigqueryMeta());
+        $command->setMeta($meta);
+
+        $response = $handler(
+            $this->projectCredentials,
+            $command,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+        $this->assertInstanceOf(CreateWorkspaceResponse::class, $response);
+
+        // Build workspace credentials
+        $wsMeta = new Any();
+        $wsMeta->pack(
+            (new GenericBackendCredentials\BigQueryCredentialsMeta())
+                ->setRegion(self::DEFAULT_LOCATION),
+        );
+        $wsCredentials = (new GenericBackendCredentials())
+            ->setHost($this->projectCredentials->getHost())
+            ->setPrincipal($response->getWorkspaceUserName())
+            ->setSecret($response->getWorkspacePassword())
+            ->setPort($this->projectCredentials->getPort());
+        $wsCredentials->setMeta($wsMeta);
+
+        $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $wsCredentials);
+
+        // 3. Verify workspace SA CAN read from both tables (via dataViewer)
+        $readResult = $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'SELECT * FROM %s.%s',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+        $this->assertCount(1, $readResult);
+
+        $readResult = $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'SELECT * FROM %s.%s',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($nonGrantedTableName),
+        )));
+        $this->assertCount(1, $readResult);
+
+        // 4. Verify workspace SA CAN write to granted table (INSERT)
+        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'INSERT INTO %s.%s (`id`, `name`) VALUES (2, \'from_workspace\')',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+
+        $readResult = $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'SELECT * FROM %s.%s ORDER BY `id`',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+        $this->assertCount(2, $readResult);
+
+        // 5. Verify workspace SA CAN UPDATE granted table
+        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'UPDATE %s.%s SET `name` = \'updated\' WHERE `id` = 1',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+
+        // 6. Verify workspace SA CAN DELETE from granted table
+        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'DELETE FROM %s.%s WHERE `id` = 2',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+
+        $readResult = $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'SELECT * FROM %s.%s',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTableName),
+        )));
+        $this->assertCount(1, $readResult);
+
+        // 6b. Verify workspace SA CAN also write to granted_table_2 (INSERT + SELECT)
+        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'INSERT INTO %s.%s (`id`, `name`) VALUES (2, \'from_workspace\')',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTable2Name),
+        )));
+
+        $readResult = $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'SELECT * FROM %s.%s ORDER BY `id`',
+            BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            BigqueryQuote::quoteSingleIdentifier($grantedTable2Name),
+        )));
+        $this->assertCount(2, $readResult);
+
+        // 7. Verify workspace SA CANNOT write to non-granted table
+        try {
+            $wsBqClient->runQuery($wsBqClient->query(sprintf(
+                'INSERT INTO %s.%s (`id`, `name`) VALUES (99, \'should_fail\')',
+                BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+                BigqueryQuote::quoteSingleIdentifier($nonGrantedTableName),
+            )));
+            $this->fail('Insert to non-granted table should fail with 403');
+        } catch (ServiceException $e) {
+            $this->assertSame(403, $e->getCode());
+            $this->assertStringContainsString('Access Denied', $e->getMessage());
+        }
+
+        // 8. Verify workspace SA CANNOT create new tables in bucket dataset
+        try {
+            $wsBqClient->runQuery($wsBqClient->query(sprintf(
+                'CREATE TABLE %s.`unauthorized_table` (`id` INT64)',
+                BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+            )));
+            $this->fail('Creating table in bucket dataset should fail');
+        } catch (ServiceException $e) {
+            $this->assertSame(403, $e->getCode());
+            $this->assertStringContainsString('bigquery.tables.create', $e->getMessage());
+        }
+
+        // 9. Verify workspace SA CANNOT delete NON-granted table from bucket dataset
+        try {
+            $wsBqClient->runQuery($wsBqClient->query(sprintf(
+                'DROP TABLE %s.%s',
+                BigqueryQuote::quoteSingleIdentifier($bucketDatasetName),
+                BigqueryQuote::quoteSingleIdentifier($nonGrantedTableName),
+            )));
+            $this->fail('Dropping non-granted table in bucket dataset should fail');
+        } catch (ServiceException $e) {
+            $this->assertSame(403, $e->getCode());
+        }
+
+        // 10. Cleanup - drop workspace with directGrantTables for IAM revoke
+        $dropHandler = new DropWorkspaceHandler($this->clientManager);
+        $dropHandler->setInternalLogger($this->log);
+        $dropCommand = (new DropWorkspaceCommand())
+            ->setWorkspaceUserName($response->getWorkspaceUserName())
+            ->setWorkspaceRoleName($response->getWorkspaceRoleName())
+            ->setWorkspaceObjectName($response->getWorkspaceObjectName());
+        $dropCommand->setIsCascade(true);
+        $dropCommand->getDirectGrantTables()[] = (new DirectGrantTable())
+            ->setPath(ProtobufHelper::arrayToRepeatedString([$bucketDatasetName]))
+            ->setTableName($grantedTableName);
+        $dropCommand->getDirectGrantTables()[] = (new DirectGrantTable())
+            ->setPath(ProtobufHelper::arrayToRepeatedString([$bucketDatasetName]))
+            ->setTableName($grantedTable2Name);
+        $dropHandler(
+            $this->projectCredentials,
+            $dropCommand,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+
+        // 11. Verify table-level IAM bindings were removed (no ghost bindings)
+        /** @var array{client_email: string} $wsKeyData */
+        $wsKeyData = json_decode($response->getWorkspaceUserName(), true, 512, JSON_THROW_ON_ERROR);
+        $wsServiceAccountEmail = $wsKeyData['client_email'];
+        $saMember = 'serviceAccount:' . $wsServiceAccountEmail;
+
+        foreach ([$grantedTableName, $grantedTable2Name] as $tableName) {
+            $table = $bqProjectClient->dataset($bucketDatasetName)->table($tableName);
+            $policy = $table->iam()->policy();
+            foreach ($policy['bindings'] ?? [] as $binding) {
+                foreach ($binding['members'] ?? [] as $member) {
+                    $this->assertNotSame(
+                        $saMember,
+                        $member,
+                        sprintf(
+                            'Table IAM binding for workspace SA should have been revoked on %s',
+                            $tableName,
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    public function testCreateWorkspaceWithNoDirectGrantTablesWorksSameAsWithout(): void
+    {
+        // Create workspace WITHOUT any direct grant tables (empty list - default behavior)
+        [
+            $wsCredentials,
+            $wsResponse,
+        ] = $this->createTestWorkspace($this->projectCredentials, $this->projectResponse);
+
+        $this->assertInstanceOf(GenericBackendCredentials::class, $wsCredentials);
+        $this->assertInstanceOf(CreateWorkspaceResponse::class, $wsResponse);
+
+        // Workspace should work normally - can create tables in own dataset
+        $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $wsCredentials);
+        $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'CREATE TABLE %s.`test_table` (`id` INT64)',
+            BigqueryQuote::quoteSingleIdentifier($wsResponse->getWorkspaceObjectName()),
+        )));
+
+        // Verify the table was created
+        $result = $wsBqClient->runQuery($wsBqClient->query(sprintf(
+            'SELECT * FROM %s.`test_table`',
+            BigqueryQuote::quoteSingleIdentifier($wsResponse->getWorkspaceObjectName()),
+        )));
+        $this->assertCount(0, $result);
+
+        // Cleanup
+        $dropHandler = new DropWorkspaceHandler($this->clientManager);
+        $dropHandler->setInternalLogger($this->log);
+        $dropCommand = (new DropWorkspaceCommand())
+            ->setWorkspaceUserName($wsResponse->getWorkspaceUserName())
+            ->setWorkspaceRoleName($wsResponse->getWorkspaceRoleName())
+            ->setWorkspaceObjectName($wsResponse->getWorkspaceObjectName());
+        $dropCommand->setIsCascade(true);
+        $dropHandler(
+            $this->projectCredentials,
+            $dropCommand,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+    }
+}


### PR DESCRIPTION
DMD-745

## Summary
- Add direct grant table support for workspace create/drop operations, allowing workspace service accounts to have write access (INSERT/UPDATE/DELETE) to specific bucket tables
- Implement IAM policy binding management in `CreateWorkspaceHandler` and cleanup in `DropWorkspaceHandler`
- Add `bigquery.dataEditor` permission constant to `IAmPermissions`
- Comprehensive functional tests covering granted/non-granted table access, negative permission tests, and IAM cleanup verification