### PR TITLE
fix: ClearWorkspace skips first page of tables when workspace has >50 objects

### DIFF
--- a/src/Handler/Workspace/Clear/ClearWorkspaceHandler.php
+++ b/src/Handler/Workspace/Clear/ClearWorkspaceHandler.php
@@ -51,14 +51,12 @@ final class ClearWorkspaceHandler extends BaseHandler
             $queryTags,
         );
 
-        $tablesInDataset = $bqClient->dataset($command->getWorkspaceObjectName())->tables();
+        $dataset = $bqClient->dataset($command->getWorkspaceObjectName());
         try {
-            /*
-             * Bigquery doesn't support something like DELETE ALL FROM SCHEMA
-             * in case if dataset not exist fetch and in case of error
-             * throw exception or return null in case of ignore error
-            */
-            $tablesInDataset->current();
+            // SUPPORT-15365: Use a separate throwaway iterator for the dataset existence check.
+            // Calling current() on an iterator before foreach corrupts pagination state —
+            // rewind() does not reset the pageToken, causing foreach to skip the first page.
+            $dataset->tables()->current();
         } catch (Throwable $e) {
             if (!$command->getIgnoreErrors()) {
                 throw $e;
@@ -69,7 +67,7 @@ final class ClearWorkspaceHandler extends BaseHandler
         $preserveTables = ProtobufHelper::repeatedStringToArray($command->getObjectsToPreserve());
 
         /** @var Table $table */
-        foreach ($tablesInDataset as $table) {
+        foreach ($dataset->tables() as $table) {
             if (in_array($table->id(), $preserveTables, true)) {
                 continue;
             }

--- a/tests/functional/UseCase/Workspace/ClearWorkspaceTest.php
+++ b/tests/functional/UseCase/Workspace/ClearWorkspaceTest.php
@@ -135,4 +135,64 @@ class ClearWorkspaceTest extends BaseCase
         $this->assertTrue($this->isDatabaseExists($projectBqClient, $response->getWorkspaceObjectName()));
         $this->assertTrue($this->isUserExists($iamService, $response->getWorkspaceUserName()));
     }
+
+    /**
+     * SUPPORT-15365: ClearWorkspace must delete all tables even when the BigQuery
+     * tables.list API paginates (default page size ~50). A previous bug caused the
+     * iterator to skip the first page after an existence-check call to current().
+     */
+    public function testClearWorkspaceWithPaginatedTables(): void
+    {
+        $tableCount = 55;
+
+        [
+            $credentials,
+            $response,
+        ] = $this->createTestWorkspace($this->projectCredentials, $this->projectResponse);
+        $this->assertInstanceOf(GenericBackendCredentials::class, $credentials);
+        $this->assertInstanceOf(CreateWorkspaceResponse::class, $response);
+
+        $wsBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $credentials);
+        $datasetName = BigqueryQuote::quoteSingleIdentifier($response->getWorkspaceObjectName());
+
+        // Create 55 tables to exceed the default page size (~50) of tables.list API
+        for ($i = 1; $i <= $tableCount; $i++) {
+            $tableName = sprintf('test_table_%02d', $i);
+            $wsBqClient->runQuery($wsBqClient->query(sprintf(
+                'CREATE TABLE %s.`%s` (`id` INTEGER);',
+                $datasetName,
+                $tableName,
+            )));
+        }
+
+        // Verify all tables exist
+        $projectBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $this->projectCredentials);
+        $tablesBeforeClear = iterator_to_array(
+            $projectBqClient->dataset($response->getWorkspaceObjectName())->tables(),
+        );
+        $this->assertCount($tableCount, $tablesBeforeClear);
+
+        // CLEAR - this must delete all 55 tables, not just those on page 2+
+        $handler = new ClearWorkspaceHandler($this->clientManager);
+        $handler->setInternalLogger($this->log);
+        $command = (new ClearWorkspaceCommand())
+            ->setWorkspaceObjectName($response->getWorkspaceObjectName());
+
+        $handler(
+            $this->projectCredentials,
+            $command,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+
+        // Verify ALL tables are gone
+        $tablesAfterClear = iterator_to_array(
+            $projectBqClient->dataset($response->getWorkspaceObjectName())->tables(),
+        );
+        $this->assertCount(0, $tablesAfterClear, sprintf(
+            'Expected 0 tables after clear, but found %d. '
+            . 'This indicates the clear operation skipped some tables due to pagination.',
+            count($tablesAfterClear),
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes a pagination bug in `ClearWorkspaceHandler` where the first page of BigQuery `tables.list` results was skipped during workspace cleanup
- The handler called `current()` on the iterator as a dataset existence check, then reused the same iterator in `foreach`. When results were paginated (>50 objects), `rewind()` failed to reset the stale `pageToken`, causing `foreach` to start from page 2
- Fix: use a throwaway iterator for the existence check and a fresh iterator for the deletion loop
- Added functional test with 55 tables to verify cleanup works correctly across pagination boundaries

## Context

- **Ref:** SUPPORT-15365 / AJDA-2343
- **Affected customer:** Heureka (project 2523) — workspace with 69 tables failed on subsequent loads with `Table already exists in workspace`
- **Reproduced in:** project 196, workspace 8508944 — [storage job 25542372](https://connection.europe-west3.gcp.keboola.com/admin/projects/196/storage/jobs?jobId=25542372)
- **Root cause:** Google Cloud PHP `PageIteratorTrait::rewind()` only sets `pageToken` when `initialResultToken` is non-null. After `current()` stores a `nextPageToken` in `callOptions`, `rewind()` does not clear it, so the next `executeCall()` fetches from page 2

## Test plan

- [x] New test `testClearWorkspaceWithPaginatedTables` creates 55 tables, clears workspace, verifies all are deleted
- [x] Test fails without fix (found 50 remaining tables), passes with fix
- [x] Existing `testClearWorkspace` still passes
- [x] CI green