### PR TITLE
feat: conditionally grant DATA_VIEWER role for workspace credentials

### DIFF
--- a/src/Handler/Workspace/Create/Helper.php
+++ b/src/Handler/Workspace/Create/Helper.php
@@ -72,6 +72,7 @@ class Helper
         string $projectName,
         ServiceAccount $wsServiceAcc,
         LoggerInterface $logger,
+        bool $includeDataViewer = true,
     ): void {
         $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($logger) {
             $logger->debug('Try set iam policy Err:' . $e->getMessage());
@@ -84,7 +85,7 @@ class Helper
         );
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy);
 
-        $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAcc, $logger): void {
+        $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAcc, $logger, $includeDataViewer): void {
             $getIamPolicyRequest = new GetIamPolicyRequest();
             $option = new GetPolicyOptions();
             $option->setRequestedPolicyVersion(self::REQUESTED_POLICY_VERSION);
@@ -96,6 +97,10 @@ class Helper
             $finalBinding[] = $actualPolicy->getBindings();
 
             foreach (CreateWorkspaceHandler::IAM_WORKSPACE_SERVICE_ACCOUNT_ROLES as $role) {
+                if ($role === IAmPermissions::ROLES_BIGQUERY_DATA_VIEWER && !$includeDataViewer) {
+                    continue;
+                }
+
                 $bigQueryJobUserBinding = new Binding();
                 $bigQueryJobUserBinding->setMembers('serviceAccount:' . $wsServiceAcc->getEmail());
                 $bigQueryJobUserBinding->setRole($role);
@@ -130,6 +135,7 @@ class Helper
                 $projectName,
                 $wsServiceAcc->getEmail(),
                 $logger,
+                $includeDataViewer,
             );
         });
     }
@@ -139,6 +145,7 @@ class Helper
         string $projectName,
         string $wsServiceAccEmail,
         LoggerInterface $logger,
+        bool $includeDataViewer = true,
     ): void {
         $retryPolicy = new CallableRetryPolicy(function (Throwable $e) use ($logger) {
             $logger->debug('Try check iam policy Err:' . $e->getMessage());
@@ -154,7 +161,7 @@ class Helper
         }
 
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy);
-        $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAccEmail, $logger): void {
+        $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAccEmail, $logger, $includeDataViewer): void {
             $logger->log(LogLevel::DEBUG, 'Try check iam policy for ' . $wsServiceAccEmail . ' in ' . $projectName);
             $getIamPolicyRequest = new GetIamPolicyRequest();
             $option = new GetPolicyOptions();
@@ -179,10 +186,16 @@ class Helper
             sort($serviceAccRoles);
 
             // ws service acc must have a job user role to be able to run queries
-            if ($serviceAccRoles !== CreateWorkspaceHandler::IAM_WORKSPACE_SERVICE_ACCOUNT_ROLES) {
+            $expectedRoles = $includeDataViewer
+                ? CreateWorkspaceHandler::IAM_WORKSPACE_SERVICE_ACCOUNT_ROLES
+                : array_values(array_filter(
+                    CreateWorkspaceHandler::IAM_WORKSPACE_SERVICE_ACCOUNT_ROLES,
+                    static fn(string $role) => $role !== IAmPermissions::ROLES_BIGQUERY_DATA_VIEWER,
+                ));
+            if ($serviceAccRoles !== $expectedRoles) {
                 throw new RuntimeException(sprintf(
                     'Workspace service account has incorrect roles. Expected roles: [%s], actual roles: [%s]',
-                    implode(',', CreateWorkspaceHandler::IAM_WORKSPACE_SERVICE_ACCOUNT_ROLES),
+                    implode(',', $expectedRoles),
                     implode(',', $serviceAccRoles),
                 ));
             }

--- a/src/Handler/Workspace/Create/Helper.php
+++ b/src/Handler/Workspace/Create/Helper.php
@@ -85,7 +85,13 @@ class Helper
         );
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy);
 
-        $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAcc, $logger, $includeDataViewer): void {
+        $proxy->call(function () use (
+            $cloudResourceManager,
+            $projectName,
+            $wsServiceAcc,
+            $logger,
+            $includeDataViewer,
+        ): void {
             $getIamPolicyRequest = new GetIamPolicyRequest();
             $option = new GetPolicyOptions();
             $option->setRequestedPolicyVersion(self::REQUESTED_POLICY_VERSION);
@@ -161,7 +167,13 @@ class Helper
         }
 
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy);
-        $proxy->call(function () use ($cloudResourceManager, $projectName, $wsServiceAccEmail, $logger, $includeDataViewer): void {
+        $proxy->call(function () use (
+            $cloudResourceManager,
+            $projectName,
+            $wsServiceAccEmail,
+            $logger,
+            $includeDataViewer,
+        ): void {
             $logger->log(LogLevel::DEBUG, 'Try check iam policy for ' . $wsServiceAccEmail . ' in ' . $projectName);
             $getIamPolicyRequest = new GetIamPolicyRequest();
             $option = new GetPolicyOptions();

--- a/src/Handler/Workspace/CreateUser/CreateWorkspaceUserHandler.php
+++ b/src/Handler/Workspace/CreateUser/CreateWorkspaceUserHandler.php
@@ -45,10 +45,6 @@ final class CreateWorkspaceUserHandler extends BaseHandler
         assert($command->getStackPrefix() !== '', 'CreateWorkspaceUserCommand.stackPrefix is required');
         assert($command->getWorkspaceId() !== '', 'CreateWorkspaceUserCommand.workspaceId is required');
         assert($command->getWorkspaceObjectName() !== '', 'CreateWorkspaceUserCommand.workspaceObjectName is required');
-        assert(
-            $command->getProjectReadOnlyRoleName() !== '',
-            'CreateWorkspaceUserCommand.projectReadOnlyRoleName is required',
-        );
 
         $projectCredentials = CredentialsHelper::getCredentialsArray($credentials);
 
@@ -88,12 +84,14 @@ final class CreateWorkspaceUserHandler extends BaseHandler
         $dataset->update(['access' => $access]);
 
         // grant project-level IAM roles
+        $hasReadOnlyAccess = $command->getProjectReadOnlyRoleName() !== '';
         $cloudResourceManager = $this->clientManager->getCloudResourceManager($credentials);
         Helper::grantProjectIamRoles(
             $cloudResourceManager,
             $projectName,
             $wsServiceAcc,
             $this->internalLogger,
+            $hasReadOnlyAccess,
         );
 
         // generate credentials

--- a/tests/functional/UseCase/Workspace/CreateDropWorkspaceUserTest.php
+++ b/tests/functional/UseCase/Workspace/CreateDropWorkspaceUserTest.php
@@ -349,6 +349,115 @@ class CreateDropWorkspaceUserTest extends BaseCase
         }
     }
 
+    /**
+     * Tests that a workspace user created WITHOUT readOnlyStorageAccess
+     * (empty projectReadOnlyRoleName) does NOT receive the DATA_VIEWER role
+     * and therefore cannot read storage bucket datasets.
+     */
+    public function testCreateWorkspaceUserWithoutReadOnlyAccess(): void
+    {
+        [
+            $wsCredentials,
+            $wsResponse,
+        ] = $this->createTestWorkspace($this->projectCredentials, $this->projectResponse);
+
+        $this->assertInstanceOf(GenericBackendCredentials::class, $wsCredentials);
+        $this->assertInstanceOf(CreateWorkspaceResponse::class, $wsResponse);
+
+        $projectCredentials = CredentialsHelper::getCredentialsArray($this->projectCredentials);
+        $projectId = $projectCredentials['project_id'];
+
+        // CREATE workspace user WITHOUT projectReadOnlyRoleName
+        $handler = new CreateWorkspaceUserHandler($this->clientManager);
+        $handler->setInternalLogger($this->log);
+
+        $shortWsId = 'WS' . self::getRand();
+        $command = (new CreateWorkspaceUserCommand())
+            ->setStackPrefix($this->getStackPrefix())
+            ->setWorkspaceId($shortWsId)
+            ->setWorkspaceObjectName($wsResponse->getWorkspaceObjectName());
+        // Note: projectReadOnlyRoleName is intentionally NOT set
+
+        $response = $handler(
+            $this->projectCredentials,
+            $command,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+
+        $this->assertInstanceOf(CreateWorkspaceUserResponse::class, $response);
+        $this->assertNotEmpty($response->getWorkspaceUserName());
+        $this->assertNotEmpty($response->getWorkspacePassword());
+
+        /** @var array<string, string> $newUserKeyData */
+        $newUserKeyData = json_decode($response->getWorkspaceUserName(), true, 512, JSON_THROW_ON_ERROR);
+        $newUserEmail = $newUserKeyData['client_email'];
+
+        // Verify the user has IAM bindings WITHOUT DATA_VIEWER
+        Helper::assertServiceAccountBindings(
+            $this->clientManager->getCloudResourceManager($this->projectCredentials),
+            'projects/' . $projectId,
+            $newUserEmail,
+            $this->log,
+            false, // includeDataViewer = false
+        );
+
+        // Build credentials for the new workspace user
+        $meta = new Any();
+        $meta->pack(
+            (new GenericBackendCredentials\BigQueryCredentialsMeta())
+                ->setRegion(self::DEFAULT_LOCATION),
+        );
+        $newUserCredentials = (new GenericBackendCredentials())
+            ->setHost($this->projectCredentials->getHost())
+            ->setPrincipal($response->getWorkspaceUserName())
+            ->setSecret($response->getWorkspacePassword())
+            ->setPort($this->projectCredentials->getPort());
+        $newUserCredentials->setMeta($meta);
+
+        $newUserBqClient = $this->clientManager->getBigQueryClient($this->testRunId, $newUserCredentials);
+
+        // Create a bucket with data
+        $tableName = 'testTable';
+        $bucketDatasetName = $this->createTestBucket($this->projectCredentials);
+        $this->createNonEmptyTableInBucket($bucketDatasetName->getCreateBucketObjectName(), $tableName);
+
+        // User CANNOT read from bucket tables (no DATA_VIEWER role)
+        try {
+            $newUserBqClient->runQuery($newUserBqClient->query(sprintf(
+                'SELECT * FROM %s.%s',
+                BigqueryQuote::quoteSingleIdentifier($bucketDatasetName->getCreateBucketObjectName()),
+                BigqueryQuote::quoteSingleIdentifier($tableName),
+            )));
+            $this->fail('Workspace user without RO access should not be able to read bucket tables');
+        } catch (ServiceException $e) {
+            $this->assertSame(403, $e->getCode());
+        }
+
+        // User CAN still create tables in own workspace
+        $newUserBqClient->runQuery($newUserBqClient->query(sprintf(
+            'CREATE TABLE %s.`test_no_ro_table` (`id` INTEGER)',
+            BigqueryQuote::quoteSingleIdentifier($wsResponse->getWorkspaceObjectName()),
+        )));
+
+        // Clean up
+        $newUserBqClient->runQuery($newUserBqClient->query(sprintf(
+            'DROP TABLE %s.`test_no_ro_table`',
+            BigqueryQuote::quoteSingleIdentifier($wsResponse->getWorkspaceObjectName()),
+        )));
+
+        $dropHandler = new DropWorkspaceUserHandler($this->clientManager);
+        $dropHandler->setInternalLogger($this->log);
+        $dropCommand = (new DropWorkspaceUserCommand())
+            ->setWorkspaceUserName($response->getWorkspaceUserName());
+        $dropHandler(
+            $this->projectCredentials,
+            $dropCommand,
+            [],
+            new RuntimeOptions(['runId' => $this->testRunId]),
+        );
+    }
+
     private function createNonEmptyTableInBucket(string $bucketDatasetName, string $tableName): void
     {
         $tableStructure = [

--- a/tests/functional/UseCase/Workspace/ResetWorkspacePasswordTest.php
+++ b/tests/functional/UseCase/Workspace/ResetWorkspacePasswordTest.php
@@ -60,8 +60,8 @@ class ResetWorkspacePasswordTest extends BaseCase
         $retryPolicy = new CallableRetryPolicy(function (Throwable $e) {
             // retry when old credentials still work (fail() throws AssertionFailedError)
             return $e->getMessage() === 'Should fail';
-        }, 10);
-        $proxy = new RetryProxy($retryPolicy, new ExponentialBackOffPolicy(10000));
+        }, 20);
+        $proxy = new RetryProxy($retryPolicy, new ExponentialBackOffPolicy(10_000, 2.0, 60_000));
         $proxy->call(function () use ($credentials): void {
             $this->clientManager->close();
             $wsBqClient = $this->clientManager->getBigQueryClient(


### PR DESCRIPTION
Jira: DMD-325
Connection PR: https://github.com/keboola/connection/pull/6851

---

## Summary
- Make `projectReadOnlyRoleName` optional in `CreateWorkspaceUserHandler` (remove assertion requiring it)
- Add `bool $includeDataViewer` parameter to `Helper::grantProjectIamRoles()` and `Helper::assertServiceAccountBindings()`
- When `includeDataViewer` is false, skip granting `ROLES_BIGQUERY_DATA_VIEWER` IAM role to workspace credentials service account

This ensures workspace credentials created for workspaces without `readOnlyStorageAccess` cannot query storage bucket datasets.

## Test plan
- [ ] E2E tests in connection repo (`WorkspacesCredentialsTest::testCredentialsWithROAccess` and `testCredentialsWithoutROAccess`) pass for BigQuery
- [ ] Existing workspace creation tests unaffected (main workspace SA still gets DATA_VIEWER)